### PR TITLE
Refactor interaction handling and remove input delays

### DIFF
--- a/Assets/InputSystem_Actions.inputactions
+++ b/Assets/InputSystem_Actions.inputactions
@@ -20,7 +20,7 @@
                     "id": "852140f2-7766-474d-8707-702459ba45f3",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": "Hold",
+                    "interactions": "",
                     "initialStateCheck": false
                 },
                 {
@@ -38,7 +38,7 @@
                     "id": "e037da3e-5ece-477d-97e7-97faa10718d5",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": "Hold",
+                    "interactions": "",
                     "initialStateCheck": false
                 }
             ],

--- a/Assets/Scripts/DialogueSystem/DialogueUI.cs
+++ b/Assets/Scripts/DialogueSystem/DialogueUI.cs
@@ -21,11 +21,9 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks {
 
     [Header("Input")]
     [Tooltip("Имя действия в Input System, которое подтверждает реплику/\"Далее\"")]
-    [SerializeField] private string advanceActionName = "Interact";
-
+    [SerializeField] private string advanceActionName = "Dialogue";
 
     private InputAction advanceAction;
-    private float suppressAdvanceUntil = 0f; // гашим подтверждение сразу после запуска диалога
 
     private bool dialogueFinished = false;
     private string lastDisplayedText = null;
@@ -56,11 +54,10 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks {
             && dialogueBox.activeSelf
             && !dialogueFinished
             && advanceAction != null
-            && Time.time >= suppressAdvanceUntil
-            && advanceAction.triggered) {
-            if (responseHandler != null && responseHandler.ResponsesCount > 0) {
+            && advanceAction.triggered)
+        {
+            if (responseHandler != null && responseHandler.ResponsesCount > 0)
                 responseHandler.ClickFirstResponse();
-            }
         }
     }
 
@@ -85,7 +82,6 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks {
         lastDisplayedText = null;
         dialogueFinished = false;
         if (dialogueBox != null) dialogueBox.SetActive(true);
-        advanceAction?.Reset();
 
 
         // IFlowObject -> IArticyObject

--- a/Assets/Scripts/PlayerInteractScript.cs
+++ b/Assets/Scripts/PlayerInteractScript.cs
@@ -1,23 +1,41 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
 
-public class PlayerInteractScript : MonoBehaviour {
-    InputAction interactAction;
+/// <summary>
+/// Handles player interaction with nearby objects.
+/// </summary>
+public class PlayerInteractScript : MonoBehaviour
+{
+    [SerializeField] private float interactRange = 2f;
 
-    void Start() {
+    private InputAction interactAction;
+
+    private void Awake()
+    {
         interactAction = InputSystem.actions.FindAction("Interact");
     }
 
-    void Update() {
-        if (interactAction != null && interactAction.triggered) {
-            float interactRange = 2f;
-            Collider[] colliderArray = Physics.OverlapSphere(transform.position, interactRange);
-            foreach (Collider collider in colliderArray) {
-                var interactable = collider.GetComponent(typeof(IInteractable)) as IInteractable;
-                if (interactable != null) {
-                    interactable.Interact();
-                }
-            }
+    private void OnEnable()
+    {
+        interactAction?.Enable();
+        if (interactAction != null)
+            interactAction.performed += OnInteractPerformed;
+    }
+
+    private void OnDisable()
+    {
+        if (interactAction != null)
+            interactAction.performed -= OnInteractPerformed;
+        interactAction?.Disable();
+    }
+
+    private void OnInteractPerformed(InputAction.CallbackContext context)
+    {
+        var hits = Physics.OverlapSphere(transform.position, interactRange);
+        foreach (var hit in hits)
+        {
+            if (hit.TryGetComponent<IInteractable>(out var interactable))
+                interactable.Interact();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Use event-based input to trigger interactions only on "Interact" action
- Strip input delays and time checks from dialogue system
- Clean up input actions and separate dialogue advancement from interaction

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a74302306c8330935216b871277b6e