### PR TITLE
Disable player control during active dialogue

### DIFF
--- a/Assets/Scripts/DialogueSystem/DialogueUI.cs
+++ b/Assets/Scripts/DialogueSystem/DialogueUI.cs
@@ -20,6 +20,7 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks {
 
     private bool dialogueFinished = false;
     private string lastDisplayedText = null;
+    public bool IsDialogueOpen { get; private set; }
 
     private void Awake() {
         if (dialogueBox != null)
@@ -68,6 +69,7 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks {
 
         // Задаём стартовую точку и не проигрываем первый узел автоматически
         flowPlayer.StartOn = startFragment;
+        IsDialogueOpen = true;
 
     }
 
@@ -76,6 +78,7 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks {
         dialogueBox?.SetActive(false);
         dialogueFinished = false;
         responseHandler?.ClearResponses();
+        IsDialogueOpen = false;
         Debug.Log("[DialogueUI] Dialogue closed by user.");
     }
 

--- a/Assets/Scripts/PlayerInteractScript.cs
+++ b/Assets/Scripts/PlayerInteractScript.cs
@@ -3,12 +3,17 @@ using UnityEngine.InputSystem;
 
 public class PlayerInteractScript : MonoBehaviour {
     InputAction interactAction;
+    private DialogueUI dialogueUI;
 
     void Start() {
         interactAction = InputSystem.actions.FindAction("Interact");
+        dialogueUI = FindObjectOfType<DialogueUI>();
     }
 
     void Update() {
+        if (dialogueUI != null && dialogueUI.IsDialogueOpen)
+            return;
+
         if (interactAction != null && interactAction.triggered) {
             Debug.Log("called");
             float interactRange = 2f;

--- a/Assets/Scripts/PlayerMovementScript.cs
+++ b/Assets/Scripts/PlayerMovementScript.cs
@@ -5,16 +5,23 @@ public class PlayerMovementScript : MonoBehaviour {
     InputAction moveAction;
     public Rigidbody rb;
     public float movementSpeed = 5;
+    private DialogueUI dialogueUI;
 
     void Start() {
         moveAction = InputSystem.actions.FindAction("Move");
+        dialogueUI = FindObjectOfType<DialogueUI>();
     }
 
     void Update() {
+        if (dialogueUI != null && dialogueUI.IsDialogueOpen) {
+            rb.linearVelocity = Vector3.zero;
+            return;
+        }
+
         Vector2 moveValue = moveAction.ReadValue<Vector2>();
         Vector3 movement = new Vector3(moveValue.x, 0, moveValue.y);
 
-        // Нормализуем вектор, чтобы скорость была одинаковой во всех направлениях
+        // РќРѕСЂРјР°Р»РёР·СѓРµРј РІРµРєС‚РѕСЂ, С‡С‚РѕР±С‹ СЃРєРѕСЂРѕСЃС‚СЊ Р±С‹Р»Р° РѕРґРёРЅР°РєРѕРІРѕР№ РІРѕ РІСЃРµС… РЅР°РїСЂР°РІР»РµРЅРёСЏС…
         if (movement.magnitude > 1f)
             movement.Normalize();
 


### PR DESCRIPTION
## Summary
- track whether a dialogue window is open
- block player movement and interactions while dialogue is active

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a7633cae5c8330a33305627419b5b5