### PR TITLE
Keep dialogue history visible

### DIFF
--- a/Assets/Scripts/DialogueSystem/DialogueUI.cs
+++ b/Assets/Scripts/DialogueSystem/DialogueUI.cs
@@ -55,7 +55,8 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks {
 
         // сброс состояния UI
         responseHandler?.ClearResponses();
-        lastDisplayedText = null;
+        lastDisplayedText = string.Empty;
+        if (textLabel != null) textLabel.text = string.Empty;
         dialogueFinished = false;
         if (dialogueBox != null) dialogueBox.SetActive(true);
 
@@ -94,14 +95,18 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks {
         string currentText = GetTextFromFlowObject(aObject);
 
         if (!string.IsNullOrEmpty(currentText)) {
-            // У нас есть текст — сразу показываем и запоминаем
-            lastDisplayedText = currentText;
-            if (textLabel != null) textLabel.text = currentText; //сюда сморим
+            // У нас есть текст — добавляем его к уже отображённому
+            if (textLabel != null) {
+                textLabel.text = string.IsNullOrEmpty(textLabel.text)
+                    ? currentText
+                    : textLabel.text + "\n" + currentText;
+                lastDisplayedText = textLabel.text;
+            }
             dialogueFinished = false;
             return;
         }
 
-        // Текущий объект не содержит текста — оставляем последнюю реплику видимой
+        // Текущий объект не содержит текста — оставляем весь предыдущий диалог видимым
         dialogueFinished = false;
         if (string.IsNullOrEmpty(lastDisplayedText)) {
             if (textLabel != null) textLabel.text = "<<< NO TEXT >>>";


### PR DESCRIPTION
## Summary
- Clear dialogue text at start and append new lines instead of replacing previous ones

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a834b1e6b48330b2e7abebdd93b93d