### PR TITLE
Add inventory UI toggle and sample item list

### DIFF
--- a/Assets/Scripts/Inventory/InventoryItemUI.cs
+++ b/Assets/Scripts/Inventory/InventoryItemUI.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+/// <summary>
+/// Represents a single item entry in the inventory UI.
+/// </summary>
+public class InventoryItemUI : MonoBehaviour
+{
+    private int _id;
+
+    /// <summary>Initializes the item UI with a specific identifier.</summary>
+    public void Initialize(int id)
+    {
+        _id = id;
+        var text = GetComponentInChildren<TMP_Text>();
+        if (text != null)
+            text.text = id.ToString();
+
+        var button = GetComponent<Button>();
+        if (button != null)
+        {
+            button.onClick.RemoveListener(OnClick);
+            button.onClick.AddListener(OnClick);
+        }
+    }
+
+    private void OnClick()
+    {
+        Debug.Log($"Clicked inventory item with id {_id}");
+    }
+}

--- a/Assets/Scripts/Inventory/InventoryItemUI.cs.meta
+++ b/Assets/Scripts/Inventory/InventoryItemUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6e123d4fd00d4e8b8d4f82ca2affd6a2

--- a/Assets/Scripts/Inventory/InventoryStorage.cs
+++ b/Assets/Scripts/Inventory/InventoryStorage.cs
@@ -10,6 +10,16 @@ public static class InventoryStorage
     // Internal list that holds the player's objects.
     private static readonly List<GameObject> _items = new List<GameObject>();
 
+    // Static constructor to seed the inventory with test items.
+    static InventoryStorage()
+    {
+        for (int i = 0; i < 5; i++)
+        {
+            var testItem = new GameObject($"TestItem_" + i);
+            _items.Add(testItem);
+        }
+    }
+
     /// <summary>
     /// Adds a new object to the inventory if it is not null and not already stored.
     /// </summary>

--- a/Assets/Scripts/Inventory/InventoryUI.cs
+++ b/Assets/Scripts/Inventory/InventoryUI.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using UnityEngine;
+using TMPro;
+using UnityEngine.UI;
+
+/// <summary>
+/// Controls the inventory interface and populates it based on items in <see cref="InventoryStorage"/>.
+/// </summary>
+public class InventoryUI : MonoBehaviour
+{
+    [Header("UI References")]
+    [SerializeField] private GameObject inventoryPanel;
+    [SerializeField] private GameObject itemButtonPrefab;
+    [SerializeField] private Transform itemsParent;
+
+    private readonly List<GameObject> _spawnedItems = new List<GameObject>();
+
+    private void Start()
+    {
+        Hide();
+        Refresh();
+    }
+
+    /// <summary>Shows the inventory interface.</summary>
+    public void Show()
+    {
+        Refresh();
+        if (inventoryPanel != null)
+            inventoryPanel.SetActive(true);
+    }
+
+    /// <summary>Hides the inventory interface.</summary>
+    public void Hide()
+    {
+        if (inventoryPanel != null)
+            inventoryPanel.SetActive(false);
+    }
+
+    /// <summary>Toggles the visibility of the inventory interface.</summary>
+    public void Toggle()
+    {
+        if (inventoryPanel == null) return;
+
+        if (inventoryPanel.activeSelf)
+            Hide();
+        else
+            Show();
+    }
+
+    /// <summary>Rebuilds the list of UI items based on <see cref="InventoryStorage.Items"/>.</summary>
+    public void Refresh()
+    {
+        foreach (var go in _spawnedItems)
+        {
+            if (go != null)
+                Destroy(go);
+        }
+        _spawnedItems.Clear();
+
+        var items = InventoryStorage.Items;
+        for (int i = 0; i < items.Count; i++)
+        {
+            var obj = Instantiate(itemButtonPrefab, itemsParent);
+            _spawnedItems.Add(obj);
+            var itemUi = obj.GetComponent<InventoryItemUI>();
+            if (itemUi == null)
+                itemUi = obj.AddComponent<InventoryItemUI>();
+            itemUi.Initialize(i);
+        }
+    }
+}

--- a/Assets/Scripts/Inventory/InventoryUI.cs.meta
+++ b/Assets/Scripts/Inventory/InventoryUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c1181d1e3e5446c69171dfc1d4541362


### PR DESCRIPTION
## Summary
- Add InventoryUI to show, hide, and rebuild inventory interface from stored items
- Add InventoryItemUI that logs its ID when clicked
- Seed InventoryStorage with five test items

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a840461a688330aa866a6991d614de