### PR TITLE
Add inventory pickup and loop reset handling

### DIFF
--- a/Assets/Scripts/Interactions/ItemPickable.cs
+++ b/Assets/Scripts/Interactions/ItemPickable.cs
@@ -1,7 +1,23 @@
 using UnityEngine;
 
-public class ItemPickable : MonoBehaviour
+public class ItemPickable : MonoBehaviour, IInteractable, ILoopResettable
 {
     [SerializeField] private string itemID;
     public bool isPicked = false;
+
+    public void Interact()
+    {
+        if (isPicked)
+            return;
+
+        InventoryStorage.Add(new Item(itemID));
+        isPicked = true;
+        gameObject.SetActive(false);
+    }
+
+    public void OnLoopReset()
+    {
+        isPicked = false;
+        gameObject.SetActive(true);
+    }
 }

--- a/Assets/Scripts/LoopResetInputScript.cs
+++ b/Assets/Scripts/LoopResetInputScript.cs
@@ -19,11 +19,18 @@ public class LoopResetInputScript : MonoBehaviour {
         resettableObjects = list.ToArray();
     }
 
+    public void LoopReset()
+    {
+        foreach (var resettable in resettableObjects) {
+            resettable.OnLoopReset();
+        }
+
+        InventoryStorage.Clear();
+    }
+
     void Update() {
         if (resetAction != null && resetAction.triggered) {
-            foreach (var resettable in resettableObjects) {
-                resettable.OnLoopReset();
-            }
+            LoopReset();
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow ItemPickable objects to be collected and stored in inventory
- centralize loop reset logic and clear inventory on reset

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a9926e799c833097321c87f29c0c9d