### PR TITLE
Fix interaction break after runtime loop reset

### DIFF
--- a/Assets/Scripts/LoopResetInputScript.cs
+++ b/Assets/Scripts/LoopResetInputScript.cs
@@ -1,28 +1,21 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
-using System.Collections.Generic;
 
 public class LoopResetInputScript : MonoBehaviour {
     private InputAction resetAction;
-    private ILoopResettable[] resettableObjects;
 
     void Start() {
         resetAction = InputSystem.actions.FindAction("Reset");
 
-        var monoBehaviours = FindObjectsOfType<MonoBehaviour>(true);
-        var list = new List<ILoopResettable>();
-        foreach (var mb in monoBehaviours) {
-            if (mb is ILoopResettable resettable) {
-                list.Add(resettable);
-            }
-        }
-        resettableObjects = list.ToArray();
     }
 
     public void LoopReset()
     {
-        foreach (var resettable in resettableObjects) {
-            resettable.OnLoopReset();
+        var monoBehaviours = FindObjectsOfType<MonoBehaviour>(true);
+        foreach (var mb in monoBehaviours) {
+            if (mb is ILoopResettable resettable) {
+                resettable.OnLoopReset();
+            }
         }
 
         InventoryStorage.Clear();


### PR DESCRIPTION
## Summary
- Re-scan for `ILoopResettable` objects each time the loop is reset to ensure all interactables are restored

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a99831dd8c8330b926d65e3f7f3c58