### PR TITLE
Track dialogue duration in game time

### DIFF
--- a/Assets/Scripts/GameTime.cs
+++ b/Assets/Scripts/GameTime.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 public class GameTime : MonoBehaviour {
 
     [SerializeField] TMP_Text clockText;
+    [SerializeField] private LoopResetInputScript loopReset;
 
     public static GameTime Instance { get; private set; }
 
@@ -16,7 +17,10 @@ public class GameTime : MonoBehaviour {
         Minutes += delta;
         while (Minutes >= 60) { Hours++; Minutes -= 60; }
         if (Hours >= 24) Hours = 0;
-        // тут можно бросать событие OnTimeChanged
+        if (Hours > 13 || (Hours == 13 && Minutes > 1)) {
+            (loopReset ??= FindObjectOfType<LoopResetInputScript>())?.LoopReset();
+        }
+        //     OnTimeChanged
     }
 
     public override string ToString() => $"{Hours:D2}:{Minutes:D2}";
@@ -24,4 +28,4 @@ public class GameTime : MonoBehaviour {
     public void Update() {
         clockText.text = GameTime.Instance.ToString();
     }
-    }
+}


### PR DESCRIPTION
## Summary
- add dialogue duration to GameTime via AddMinutes and reset loop past 13:01
- consume DialogueFragment Duration property when fragments play

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68a9b76cc03c8330bd8422ee75f0c2b2