### PR TITLE
Prevent respawning items already in inventory when artefact retained

### DIFF
--- a/Assets/Scripts/Interactions/ItemPickable.cs
+++ b/Assets/Scripts/Interactions/ItemPickable.cs
@@ -2,8 +2,7 @@ using System;
 using UnityEngine;
 
 public class ItemPickable : MonoBehaviour, IInteractable, ILoopResettable {
-    [SerializeField] private string itemID;
-    [SerializeField] private bool dontRespawnIfHasArtefact; // <- добавь
+    [SerializeField] private string itemID; 
 
     public bool isPicked = false;
 
@@ -15,11 +14,10 @@ public class ItemPickable : MonoBehaviour, IInteractable, ILoopResettable {
     }
 
     public void OnLoopReset() {
-        if (dontRespawnIfHasArtefact &&
-            GlobalVariables.Instance != null &&
+        if (GlobalVariables.Instance != null &&
             GlobalVariables.Instance.player.hasArtifact &&
-            itemID.Equals(ItemIds.InventoryArtefact, StringComparison.OrdinalIgnoreCase)) {
-            // не респавним, игрок уже владеет артефактом
+            InventoryStorage.Contains(itemID)) {
+            // item already in inventory, do not respawn
             gameObject.SetActive(false);
             return;
         }


### PR DESCRIPTION
## Summary
- Keep pickable items disabled on loop reset if the player retains the artefact and the item is already in inventory

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ab024416fc833092ed4942e7f9150a