### PR TITLE
Handle loop reset per item instance in inventory

### DIFF
--- a/Assets/Scripts/ArticyInventorySync.cs
+++ b/Assets/Scripts/ArticyInventorySync.cs
@@ -35,7 +35,7 @@ public static class ArticyInventorySync {
 
                 string itemId = name.Substring(Prefix.Length, name.Length - Prefix.Length - SuffixDelta.Length);
 
-                if (delta > 0) InventoryStorage.Add(new Item(itemId, delta));
+                if (delta > 0) InventoryStorage.Add(itemId, delta);
                 else InventoryStorage.Remove(itemId, -delta);
 
                 p.SetValue(itm, 0); // чтобы не применить второй раз

--- a/Assets/Scripts/Interactions/ItemPickable.cs
+++ b/Assets/Scripts/Interactions/ItemPickable.cs
@@ -2,13 +2,19 @@ using System;
 using UnityEngine;
 
 public class ItemPickable : MonoBehaviour, IInteractable, ILoopResettable {
-    [SerializeField] private string itemID; 
+    [SerializeField] private string itemID;
+    [SerializeField] private string instanceID;
 
     public bool isPicked = false;
 
+    private void Awake() {
+        if (string.IsNullOrEmpty(instanceID))
+            instanceID = Guid.NewGuid().ToString();
+    }
+
     public void Interact() {
         if (isPicked) return;
-        InventoryStorage.Add(new Item(itemID));
+        InventoryStorage.Add(itemID, instanceId: instanceID);
         isPicked = true;
         gameObject.SetActive(false);
     }
@@ -16,7 +22,7 @@ public class ItemPickable : MonoBehaviour, IInteractable, ILoopResettable {
     public void OnLoopReset() {
         if (GlobalVariables.Instance != null &&
             GlobalVariables.Instance.player.hasArtifact &&
-            InventoryStorage.Contains(itemID)) {
+            InventoryStorage.ContainsInstance(itemID, instanceID)) {
             // item already in inventory, do not respawn
             gameObject.SetActive(false);
             return;


### PR DESCRIPTION
## Summary
- Track individual item instances in `InventoryStorage` via unique IDs while keeping aggregated counts
- Assign each `ItemPickable` a persistent instance ID and check inventory by instance on loop reset
- Update Articy inventory sync to use new storage API

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ab09e8283c833089131b7d3f615a29