### PR TITLE
Trigger murder attempt event and reset EVT variables

### DIFF
--- a/Assets/Scripts/ArticyReset.cs
+++ b/Assets/Scripts/ArticyReset.cs
@@ -3,12 +3,11 @@ using System.Reflection;
 using UnityEngine;
 using Articy.Unity;
 using Articy.World_Of_Red_Moon.GlobalVariables;
-// using Articy.World_Of_Red_Moon; // если у теб€ другой namespace Ч оставь как есть/поправь
 
 public static class ArticyReset {
     /// <summary>
-    /// —брасывает ¬—≈ переменные в ArticyGlobalVariables.Default.RQUE:
-    /// int -> 0, bool -> false, string -> "" (остальные типы пропускаем).
+    ///     ArticyGlobalVariables.Default.RQUE:
+    /// int -> 0, bool -> false, string -> "".
     /// </summary>
     public static void ResetRQUE() {
         try {
@@ -27,8 +26,8 @@ public static class ArticyReset {
                 else if (t == typeof(string)) val = string.Empty;
                 else if (t == typeof(float)) val = 0f;
                 else if (t == typeof(double)) val = 0d;
-                else if (t.IsEnum) val = Enum.GetValues(t).GetValue(0); // дефолт enum
-                else continue; // неизвестные типы не трогаем
+                else if (t.IsEnum) val = Enum.GetValues(t).GetValue(0); // enum
+                else continue;
 
                 p.SetValue(rque, val);
                 changed++;
@@ -37,6 +36,39 @@ public static class ArticyReset {
             Debug.Log($"[ArticyReset] RQUE cleared: {changed} variables.");
         } catch (Exception e) {
             Debug.LogWarning($"[ArticyReset] ResetRQUE error: {e.Message}");
+        }
+    }
+
+    /// <summary>
+    ///     Resets ArticyGlobalVariables.Default.EVT similar to RQUE.
+    /// </summary>
+    public static void ResetEVT() {
+        try {
+            var evt = ArticyGlobalVariables.Default.EVT;
+            var props = evt.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public);
+
+            int changed = 0;
+            foreach (var p in props) {
+                if (!p.CanWrite) continue;
+
+                var t = p.PropertyType;
+                object val = null;
+
+                if (t == typeof(int)) val = 0;
+                else if (t == typeof(bool)) val = false;
+                else if (t == typeof(string)) val = string.Empty;
+                else if (t == typeof(float)) val = 0f;
+                else if (t == typeof(double)) val = 0d;
+                else if (t.IsEnum) val = Enum.GetValues(t).GetValue(0);
+                else continue;
+
+                p.SetValue(evt, val);
+                changed++;
+            }
+
+            Debug.Log($"[ArticyReset] EVT cleared: {changed} variables.");
+        } catch (Exception e) {
+            Debug.LogWarning($"[ArticyReset] ResetEVT error: {e.Message}");
         }
     }
 }

--- a/Assets/Scripts/GameTime.cs
+++ b/Assets/Scripts/GameTime.cs
@@ -1,3 +1,4 @@
+using System;
 using TMPro;
 using UnityEngine;
 
@@ -11,6 +12,8 @@ public class GameTime : MonoBehaviour {
     public int Hours { get; set; } = 12;
     public int Minutes { get; set; } = 12;
 
+    public event Action<int, int> OnTimeChanged;
+
     void Awake() => Instance = this;
 
     public void AddMinutes(int delta) {
@@ -20,8 +23,8 @@ public class GameTime : MonoBehaviour {
         if (Hours > 13 || (Hours == 13 && Minutes > 1)) {
             (loopReset ??= FindObjectOfType<LoopResetInputScript>())?.LoopReset();
         }
-        //     OnTimeChanged
         Update();
+        OnTimeChanged?.Invoke(Hours, Minutes);
     }
 
     public override string ToString() => $"{Hours:D2}:{Minutes:D2}";

--- a/Assets/Scripts/LoopResetInputScript.cs
+++ b/Assets/Scripts/LoopResetInputScript.cs
@@ -6,7 +6,6 @@ public class LoopResetInputScript : MonoBehaviour {
 
     void Start() {
         resetAction = InputSystem.actions.FindAction("Reset");
-
     }
 
     public void LoopReset() {
@@ -17,8 +16,9 @@ public class LoopResetInputScript : MonoBehaviour {
         GameTime.Instance.Hours = 12;
         GameTime.Instance.Minutes = 12;
 
-        // Надёжная проверка наличия артефакта: сначала из GlobalVariables, если он уже жив,
-        // иначе — прямо из InventoryStorage (фоллбек).
+        ArticyReset.ResetRQUE();
+        ArticyReset.ResetEVT();
+
         bool hasArtefactNow =
             (GlobalVariables.Instance != null && GlobalVariables.Instance.player.hasArtifact)
             || InventoryStorage.Contains("InventoryArtefact");

--- a/Assets/Scripts/MurderAttemptEvent.cs
+++ b/Assets/Scripts/MurderAttemptEvent.cs
@@ -1,0 +1,65 @@
+using System.Collections;
+using UnityEngine;
+using Articy.World_Of_Red_Moon.GlobalVariables;
+
+public class MurderAttemptEvent : MonoBehaviour, ILoopResettable {
+    [SerializeField] private Transform firstNpcA;
+    [SerializeField] private Transform firstNpcB;
+    [SerializeField] private Transform secondNpcA;
+    [SerializeField] private Transform secondNpcB;
+    [SerializeField] private Transform secondNpcC;
+    [SerializeField] private Transform secondNpcD;
+    [SerializeField] private Transform secondNpcE;
+    [SerializeField] private PlayerMovementScript playerMovement;
+    [SerializeField] private PlayerInteractScript playerInteract;
+
+    private bool triggered;
+
+    void Start() {
+        GameTime.Instance.OnTimeChanged += OnTimeChanged;
+    }
+
+    void OnDestroy() {
+        if (GameTime.Instance != null)
+            GameTime.Instance.OnTimeChanged -= OnTimeChanged;
+    }
+
+    void OnTimeChanged(int hours, int minutes) {
+        if (!triggered && hours == 12 && minutes == 42) {
+            triggered = true;
+            StartCoroutine(EventSequence());
+        }
+    }
+
+    IEnumerator EventSequence() {
+        var dialogue = FindObjectOfType<DialogueUI>();
+        dialogue?.CloseDialogue();
+
+        if (playerMovement != null) playerMovement.enabled = false;
+        if (playerInteract != null) playerInteract.enabled = false;
+
+        yield return new WaitForSeconds(3f);
+
+        if (firstNpcA != null) firstNpcA.position = Vector3.zero; // TODO: specify target position
+        if (firstNpcB != null) firstNpcB.position = Vector3.zero; // TODO: specify target position
+
+        yield return new WaitForSeconds(3f);
+
+        if (secondNpcA != null) secondNpcA.position = Vector3.zero; // TODO: specify target position
+        if (secondNpcB != null) secondNpcB.position = Vector3.zero; // TODO: specify target position
+        if (secondNpcC != null) secondNpcC.position = Vector3.zero; // TODO: specify target position
+        if (secondNpcD != null) secondNpcD.position = Vector3.zero; // TODO: specify target position
+        if (secondNpcE != null) secondNpcE.position = Vector3.zero; // TODO: specify target position
+
+        ArticyGlobalVariables.Default.EVT.event_murderAttempt = 1;
+
+        if (playerMovement != null) playerMovement.enabled = true;
+        if (playerInteract != null) playerInteract.enabled = true;
+
+        yield break;
+    }
+
+    public void OnLoopReset() {
+        triggered = false;
+    }
+}

--- a/Assets/Scripts/MurderAttemptEvent.cs.meta
+++ b/Assets/Scripts/MurderAttemptEvent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 892355573d784238a326c4212904d649


### PR DESCRIPTION
## Summary
- Add time-change event in `GameTime`
- Implement `MurderAttemptEvent` sequence for 12:42
- Reset EVT variables alongside RQUE during loop reset

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ab0d15d444833088454d688ca5a062