### PR TITLE
Fix dialogue closure and add camera zoom to murder event

### DIFF
--- a/Assets/Scripts/DialogueSystem/DialogueUI.cs
+++ b/Assets/Scripts/DialogueSystem/DialogueUI.cs
@@ -82,6 +82,10 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
         dialogueFinished = false;
         responseHandler?.ClearResponses();
         IsDialogueOpen = false;
+
+        // остановим flowPlayer, чтобы он не открывал окно снова
+        flowPlayer?.Stop();
+
         Debug.Log("[DialogueUI] Dialogue closed by user.");
         GlobalVariables.Instance?.GetKnowledge();
         GlobalVariables.Instance?.GetTempObjectives();


### PR DESCRIPTION
## Summary
- Stop flow player when closing dialogue to prevent reopening
- Zoom camera out during murder event and restore previous view

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ab18d34c9c833087276f19bb4736d8