### PR TITLE
Ensure murder event closes dialogue

### DIFF
--- a/Assets/Scripts/MurderAttemptEvent.cs
+++ b/Assets/Scripts/MurderAttemptEvent.cs
@@ -48,6 +48,8 @@ public class MurderAttemptEvent : MonoBehaviour, ILoopResettable {
     IEnumerator EventSequence() {
 
         GlobalVariables.Instance?.ForceCloseDialogue();
+        foreach (var dialogue in FindObjectsOfType<DialogueUI>(true))
+            dialogue.CloseDialogue();
 
 
         if (playerMovement != null) playerMovement.enabled = false;


### PR DESCRIPTION
## Summary
- Force close any active dialogues when the murder event starts

No tests were run due to user request.

------
https://chatgpt.com/codex/tasks/task_e_68ab1e4074508330a370df475cdd1778