### PR TITLE
Ensure murder event closes dialogue

### DIFF
--- a/Assets/Scripts/MurderAttemptEvent.cs
+++ b/Assets/Scripts/MurderAttemptEvent.cs
@@ -46,9 +46,19 @@ public class MurderAttemptEvent : MonoBehaviour, ILoopResettable {
     }
 
     IEnumerator EventSequence() {
-
         GlobalVariables.Instance?.ForceCloseDialogue();
-
+        var monoBehaviours = FindObjectsOfType<MonoBehaviour>(true);
+        foreach (var mb in monoBehaviours) {
+            if (ReferenceEquals(mb, this))
+                continue;
+            if (mb is ILoopResettable resettable) {
+                try {
+                    resettable.OnLoopReset();
+                } catch (System.Exception e) {
+                    Debug.LogWarning($"[MurderAttemptEvent] OnLoopReset error on {mb.name}: {e}");
+                }
+            }
+        }
 
         if (playerMovement != null) playerMovement.enabled = false;
         if (playerInteract != null) playerInteract.enabled = false;


### PR DESCRIPTION
## Summary
- Use loop-reset loop to close dialogue components when the murder sequence begins

No tests were run due to user request.

------
https://chatgpt.com/codex/tasks/task_e_68ab1e4074508330a370df475cdd1778