### PR TITLE
Ensure murder event dialogue closes correctly

### DIFF
--- a/Assets/Scripts/DialogueSystem/DialogueUI.cs
+++ b/Assets/Scripts/DialogueSystem/DialogueUI.cs
@@ -61,6 +61,7 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
         if (textLabel != null) textLabel.text = string.Empty;
         dialogueFinished = false;
         if (dialogueBox != null) dialogueBox.SetActive(true);
+        if (flowPlayer != null) flowPlayer.enabled = true;
 
 
         // Убедимся, что стартуем именно с нужного DialogueFragment
@@ -82,6 +83,11 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
         dialogueFinished = false;
         responseHandler?.ClearResponses();
         IsDialogueOpen = false;
+        if (flowPlayer != null) {
+            var stopMethod = flowPlayer.GetType().GetMethod("Stop", BindingFlags.Public | BindingFlags.Instance);
+            stopMethod?.Invoke(flowPlayer, null);
+            flowPlayer.enabled = false;
+        }
 
         Debug.Log("[DialogueUI] Dialogue closed by user.");
         GlobalVariables.Instance?.GetKnowledge();


### PR DESCRIPTION
## Summary
- Prevent dialogue UI from reopening by stopping the Articy flow player when a dialogue closes
- Reactivate the flow player when a new dialogue starts

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ab25fa80008330a72aefc54108ca2e