### PR TITLE
Fix murder event dialogue closing

### DIFF
--- a/Assets/Scripts/DialogueSystem/DialogueUI.cs
+++ b/Assets/Scripts/DialogueSystem/DialogueUI.cs
@@ -23,6 +23,7 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
     public bool IsDialogueOpen { get; private set; }
 
     public IObjectWithFeatureDuration kek;
+    private bool suppressOnFlowPause = false;
 
     private void Awake() {
         if (dialogueBox != null)
@@ -84,6 +85,7 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
         responseHandler?.ClearResponses();
         IsDialogueOpen = false;
         if (flowPlayer != null) {
+            suppressOnFlowPause = true;
             var stopMethod = flowPlayer.GetType().GetMethod("Stop", BindingFlags.Public | BindingFlags.Instance);
             stopMethod?.Invoke(flowPlayer, null);
             flowPlayer.enabled = false;
@@ -102,6 +104,10 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
 
     // ======== IArticyFlowPlayerCallbacks ========
     public void OnFlowPlayerPaused(IFlowObject aObject) {
+        if (suppressOnFlowPause) {
+            suppressOnFlowPause = false;
+            return;
+        }
         // Добавим время из свойства Duration
         if (aObject is IObjectWithFeatureDuration)
         {


### PR DESCRIPTION
## Summary
- Prevent `DialogueUI` from reopening after forced close by suppressing the `OnFlowPlayerPaused` callback
- Use suppression flag inside `CloseDialogue` to ensure murder event shuts dialog windows

## Testing
- No tests were run


------
https://chatgpt.com/codex/tasks/task_e_68ab2b4b2bcc8330ace084ef343fc239