### PR TITLE
Add loop counter UI and streamline logging

### DIFF
--- a/Assets/ArticyImporter/Helper/Scripts/ArticyDebugFlowPlayer.cs
+++ b/Assets/ArticyImporter/Helper/Scripts/ArticyDebugFlowPlayer.cs
@@ -41,7 +41,7 @@ public class ArticyDebugFlowPlayer : MonoBehaviour, IArticyFlowPlayerCallbacks
 	{
 		// you could assign this via the inspector but this works equally well for our purpose.
 		flowPlayer = GetComponent<ArticyFlowPlayer>();
-		Debug.Assert(flowPlayer != null, "ArticyDebugFlowPlayer needs the ArticyFlowPlayer component!.");
+		// Debug.Assert(flowPlayer != null, "ArticyDebugFlowPlayer needs the ArticyFlowPlayer component!.");
 
 		// by clearing at start we can safely have a prefab instantiated in the editor for our convenience and automatically get rid of it when we play.
 		ClearAllBranches();
@@ -170,6 +170,6 @@ public class ArticyDebugFlowPlayer : MonoBehaviour, IArticyFlowPlayerCallbacks
 		var pointerData = aData as PointerEventData;
 		if (pointerData != null)
 			GUIUtility.systemCopyBuffer = pointerData.pointerPress.GetComponent<Text>().text;
-		Debug.LogFormat("Copied text \"{0}\" into clipboard!", GUIUtility.systemCopyBuffer);
+		// Debug.LogFormat("Copied text \"{0}\" into clipboard!", GUIUtility.systemCopyBuffer);
 	}
 }

--- a/Assets/Scripts/ArticyInventorySync.cs
+++ b/Assets/Scripts/ArticyInventorySync.cs
@@ -44,10 +44,10 @@ public static class ArticyInventorySync {
 
             if (applied > 0) {
                 PushAllCountsToArticy();
-                Debug.Log($"[ArticyInventorySync] Applied {applied} item deltas from ITM.");
+                // Debug.Log($"[ArticyInventorySync] Applied {applied} item deltas from ITM.");
             }
         } catch (Exception e) {
-            Debug.LogWarning($"[ArticyInventorySync] ApplyItemDeltasFromArticy error: {e.Message}");
+            // Debug.LogWarning($"[ArticyInventorySync] ApplyItemDeltasFromArticy error: {e.Message}");
         }
     }
 
@@ -82,7 +82,7 @@ public static class ArticyInventorySync {
                     p.SetValue(itm, 0);
             }
         } catch (Exception e) {
-            Debug.LogWarning($"[ArticyInventorySync] PushAllCountsToArticy error: {e.Message}");
+            // Debug.LogWarning($"[ArticyInventorySync] PushAllCountsToArticy error: {e.Message}");
         }
     }
 
@@ -103,9 +103,9 @@ public static class ArticyInventorySync {
                 }
             }
             if (cleared > 0)
-                Debug.Log($"[ArticyInventorySync] Cleared {cleared} item deltas in ITM.");
+                // Debug.Log($"[ArticyInventorySync] Cleared {cleared} item deltas in ITM.");
         } catch (Exception e) {
-            Debug.LogWarning($"[ArticyInventorySync] ResetAllItemDeltas error: {e.Message}");
+            // Debug.LogWarning($"[ArticyInventorySync] ResetAllItemDeltas error: {e.Message}");
         }
     }
 }

--- a/Assets/Scripts/ArticyReset.cs
+++ b/Assets/Scripts/ArticyReset.cs
@@ -33,9 +33,9 @@ public static class ArticyReset {
                 changed++;
             }
 
-            Debug.Log($"[ArticyReset] RQUE cleared: {changed} variables.");
+            // Debug.Log($"[ArticyReset] RQUE cleared: {changed} variables.");
         } catch (Exception e) {
-            Debug.LogWarning($"[ArticyReset] ResetRQUE error: {e.Message}");
+            // Debug.LogWarning($"[ArticyReset] ResetRQUE error: {e.Message}");
         }
     }
 
@@ -66,9 +66,9 @@ public static class ArticyReset {
                 changed++;
             }
 
-            Debug.Log($"[ArticyReset] EVT cleared: {changed} variables.");
+            // Debug.Log($"[ArticyReset] EVT cleared: {changed} variables.");
         } catch (Exception e) {
-            Debug.LogWarning($"[ArticyReset] ResetEVT error: {e.Message}");
+            // Debug.LogWarning($"[ArticyReset] ResetEVT error: {e.Message}");
         }
     }
 }

--- a/Assets/Scripts/DialogueSystem/DialogueUI.cs
+++ b/Assets/Scripts/DialogueSystem/DialogueUI.cs
@@ -32,7 +32,7 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
 
     private void Start() {
         if (flowPlayer == null) {
-            Debug.LogError("[DialogueUI] flowPlayer не назначен.");
+            // Debug.LogError("[DialogueUI] flowPlayer не назначен.");
             return;
         }
 
@@ -43,7 +43,7 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
     // ======== ПУБЛИЧНЫЕ API ДЛЯ ЗАПУСКА ДИАЛОГА ========
     public void StartDialogue(ArticyRef startRef) {
         if (startRef == null || flowPlayer == null) {
-            Debug.LogWarning("[DialogueUI] StartDialogue(ArticyRef) — пустой startRef или flowPlayer.");
+            // Debug.LogWarning("[DialogueUI] StartDialogue(ArticyRef) — пустой startRef или flowPlayer.");
             return;
         }
         var obj = startRef.GetObject() as IFlowObject;
@@ -52,7 +52,7 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
 
     public void StartDialogue(IFlowObject startObject) {
         if (startObject == null || flowPlayer == null) {
-            Debug.LogWarning("[DialogueUI] StartDialogue(IFlowObject) — пустой startObject или flowPlayer.");
+            // Debug.LogWarning("[DialogueUI] StartDialogue(IFlowObject) — пустой startObject или flowPlayer.");
             return;
         }
 
@@ -68,7 +68,7 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
         // Убедимся, что стартуем именно с нужного DialogueFragment
         var startFragment = startObject as DialogueFragment;
         if (startFragment == null) {
-            Debug.LogError("[DialogueUI] startObject не является DialogueFragment — не могу запустить диалог.");
+            // Debug.LogError("[DialogueUI] startObject не является DialogueFragment — не могу запустить диалог.");
             return;
         }
 
@@ -91,7 +91,7 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
             flowPlayer.enabled = false;
         }
 
-        Debug.Log("[DialogueUI] Dialogue closed by user.");
+        // Debug.Log("[DialogueUI] Dialogue closed by user.");
         GlobalVariables.Instance?.GetKnowledge();
         GlobalVariables.Instance?.GetTempObjectives();
         GlobalVariables.Instance?.GetItems();
@@ -114,18 +114,16 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
             kek = (IObjectWithFeatureDuration)aObject;
             int duration = ((int)kek.GetFeatureDuration().Minutes);
 
-            Debug.Log(duration);
+            // Debug.Log(duration);
             if (duration > 0)
             {
                 GameTime.Instance?.AddMinutes(duration);
-                Debug.Log("Added minutes");
+                // Debug.Log("Added minutes");
             }
         }
 
         // Очистим старые ответы (если были)
         responseHandler?.ClearResponses();
-
-      //  dialogueBox?.SetActive(true);
         if (dialogueSpeaker != null) dialogueSpeaker.text = GetSpeakerDisplayName(aObject);
 
         // Попытаемся получить текст прямо с текущего объекта
@@ -245,17 +243,15 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
     private int GetDurationFromFlowObject(IFlowObject obj)
     {
 
-        //if (obj == null) return 0;
-
         try {
 
             var type = obj.GetType();
             var durProp = type.GetProperty("Duration", BindingFlags.Public | BindingFlags.Instance);
-            Debug.Log(durProp);
+            // Debug.Log(durProp);
             if (durProp != null)
             {
                 var val = durProp.GetValue(obj);
-                Debug.Log(val);
+                // Debug.Log(val);
                 if (val is int i) return i;
                 if (val != null && int.TryParse(val.ToString(), out i)) return i;
             }

--- a/Assets/Scripts/DialogueSystem/ResponseHandler.cs
+++ b/Assets/Scripts/DialogueSystem/ResponseHandler.cs
@@ -68,7 +68,7 @@ public class ResponseHandler : MonoBehaviour {
 
         tempResponseButtons.Add(buttonObj);
         responseBox.gameObject.SetActive(true);
-        Debug.Log("[ResponseHandler] Single button created: " + text);
+        // Debug.Log("[ResponseHandler] Single button created: " + text);
     }
 
     /// <summary>
@@ -118,7 +118,7 @@ public class ResponseHandler : MonoBehaviour {
 
         if (flowPlayer != null && branch != null)
             flowPlayer.Play(branch);
-        Debug.Log("picked");
+        // Debug.Log("picked");
     }
 
     /// <summary>

--- a/Assets/Scripts/Interactions/DialogueInteractable.cs
+++ b/Assets/Scripts/Interactions/DialogueInteractable.cs
@@ -27,13 +27,13 @@ public abstract class DialogueInteractable : MonoBehaviour, IInteractable
 
         if (cachedDialogueUI == null)
         {
-            Debug.LogWarning($"[{nameof(DialogueInteractable)}] DialogueUI not found.");
+            // Debug.LogWarning($"[{nameof(DialogueInteractable)}] DialogueUI not found.");
             return;
         }
 
         if (dialogueStart == null)
         {
-            Debug.LogWarning($"[{nameof(DialogueInteractable)}] dialogueStart is not assigned for {name}.");
+            // Debug.LogWarning($"[{nameof(DialogueInteractable)}] dialogueStart is not assigned for {name}.");
             return;
         }
 

--- a/Assets/Scripts/Interactions/ItemPickable.cs
+++ b/Assets/Scripts/Interactions/ItemPickable.cs
@@ -15,6 +15,7 @@ public class ItemPickable : MonoBehaviour, IInteractable, ILoopResettable {
     public void Interact() {
         if (isPicked) return;
         InventoryStorage.Add(itemID, instanceId: instanceID);
+        Debug.Log($"[Item] Received: {itemID}");
         isPicked = true;
         gameObject.SetActive(false);
     }

--- a/Assets/Scripts/Inventory/InventoryInputScript.cs
+++ b/Assets/Scripts/Inventory/InventoryInputScript.cs
@@ -17,13 +17,13 @@ public class InventoryInputScript : MonoBehaviour {
             return;
 
         if (inventoryAction != null && inventoryAction.triggered) {
-            Debug.Log("opened inv");
+            // Debug.Log("opened inv");
             inventoryUI.Show();
         }
             
 
         if (escapeAction != null && escapeAction.triggered) {
-            Debug.Log("close inv");
+            // Debug.Log("close inv");
             inventoryUI.Hide();
         }
             

--- a/Assets/Scripts/Inventory/InventoryItemUI.cs
+++ b/Assets/Scripts/Inventory/InventoryItemUI.cs
@@ -28,6 +28,6 @@ public class InventoryItemUI : MonoBehaviour
     private void OnClick()
     {
         if (_item != null)
-            Debug.Log($"Clicked inventory item {_item.TechnicalName}");
+            // Debug.Log($"Clicked inventory item {_item.TechnicalName}");
     }
 }

--- a/Assets/Scripts/KnowledgeManager.cs
+++ b/Assets/Scripts/KnowledgeManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text;
+using UnityEngine;
 
 public static class KnowledgeManager {
     public class Knowledge {
@@ -9,7 +10,8 @@ public static class KnowledgeManager {
     private static readonly Dictionary<string, Knowledge> knowledges = new();
 
     public static void AddKnowledge(string name) {
-        knowledges[name] = new Knowledge { Name = name};
+        knowledges[name] = new Knowledge { Name = name };
+        Debug.Log($"[Knowledge] Received: {name}");
     }
 
     public static string DisplayKnowledges() {
@@ -23,6 +25,5 @@ public static class KnowledgeManager {
 
     public static void ResetKnowledges() => knowledges.Clear();
 
-    // Удобные проверки для диалогов
     public static bool HasKnowledge(string name) => knowledges.ContainsKey(name);
 }

--- a/Assets/Scripts/LoopCounter.cs
+++ b/Assets/Scripts/LoopCounter.cs
@@ -1,0 +1,25 @@
+using TMPro;
+using UnityEngine;
+
+public class LoopCounter : MonoBehaviour, ILoopResettable {
+    [SerializeField] private TMP_Text loopCounterText;
+
+    public static LoopCounter Instance { get; private set; }
+
+    public int Count { get; private set; } = 0;
+
+    void Awake() {
+        Instance = this;
+        UpdateText();
+    }
+
+    public void OnLoopReset() {
+        Count++;
+        UpdateText();
+    }
+
+    private void UpdateText() {
+        if (loopCounterText != null)
+            loopCounterText.text = Count.ToString();
+    }
+}

--- a/Assets/Scripts/LoopResetInputScript.cs
+++ b/Assets/Scripts/LoopResetInputScript.cs
@@ -9,8 +9,6 @@ public class LoopResetInputScript : MonoBehaviour {
     }
 
     public void LoopReset() {
-        Debug.Log("[LoopReset] start");
-
         QuestManager.ResetTemporary();
 
         GameTime.Instance.Hours = 12;
@@ -23,13 +21,8 @@ public class LoopResetInputScript : MonoBehaviour {
             (GlobalVariables.Instance != null && GlobalVariables.Instance.player.hasArtifact)
             || InventoryStorage.Contains("InventoryArtefact");
 
-        Debug.Log($"[LoopReset] GV.Instance={(GlobalVariables.Instance != null)} hasArtifact={GlobalVariables.Instance?.player.hasArtifact} fallbackContains={InventoryStorage.Contains("InventoryArtefact")} -> hasArtefactNow={hasArtefactNow}");
-
         if (!hasArtefactNow) {
-            Debug.Log("[LoopReset] clearing inventory (no artefact)");
             InventoryStorage.Clear();
-        } else {
-            Debug.Log("[LoopReset] preserving inventory (artefact present)");
         }
 
         var monoBehaviours = FindObjectsOfType<MonoBehaviour>(true);
@@ -38,12 +31,10 @@ public class LoopResetInputScript : MonoBehaviour {
                 try {
                     resettable.OnLoopReset();
                 } catch (System.Exception e) {
-                    Debug.LogWarning($"[LoopReset] OnLoopReset error on {mb.name}: {e}");
+                    // Debug.LogWarning($"[LoopReset] OnLoopReset error on {mb.name}: {e}");
                 }
             }
         }
-
-        Debug.Log("[LoopReset] end");
     }
 
     void Update() {

--- a/Assets/Scripts/MurderAttemptEvent.cs
+++ b/Assets/Scripts/MurderAttemptEvent.cs
@@ -60,16 +60,16 @@ public class MurderAttemptEvent : MonoBehaviour, ILoopResettable {
 
         yield return new WaitForSeconds(3f);
 
-        if (firstNpcA != null) firstNpcA.position = spawnAo1.position; // TODO: specify target position
-        if (firstNpcB != null) firstNpcB.position = spawnTomas1.position; // TODO: specify target position
+        if (firstNpcA != null) firstNpcA.position = spawnAo1.position;
+        if (firstNpcB != null) firstNpcB.position = spawnTomas1.position;
 
         yield return new WaitForSeconds(3f);
 
-        if (secondNpcA != null) secondNpcA.position =spawnAo2.position;
-        if (secondNpcB != null) secondNpcB.position = spawnTomas2.position;// TODO: specify target position
-        if (secondNpcC != null) secondNpcC.position = spawnTasha.position; // TODO: specify target position
-        if (secondNpcD != null) secondNpcD.position = spawnGuardM.position; // TODO: specify target position
-        if (secondNpcE != null) secondNpcE.position = spawnGuardD.position; // TODO: specify target position
+        if (secondNpcA != null) secondNpcA.position = spawnAo2.position;
+        if (secondNpcB != null) secondNpcB.position = spawnTomas2.position;
+        if (secondNpcC != null) secondNpcC.position = spawnTasha.position;
+        if (secondNpcD != null) secondNpcD.position = spawnGuardM.position;
+        if (secondNpcE != null) secondNpcE.position = spawnGuardD.position;
 
         ArticyGlobalVariables.Default.EVT.event_murderAttempt = 1;
 
@@ -78,7 +78,7 @@ public class MurderAttemptEvent : MonoBehaviour, ILoopResettable {
 
         if (playerMovement != null) playerMovement.enabled = true;
         if (playerInteract != null) playerInteract.enabled = true;
-
+        Debug.Log("[MurderAttemptEvent] event ended");
         yield break;
     }
 

--- a/Assets/Scripts/PlayerInteractScript.cs
+++ b/Assets/Scripts/PlayerInteractScript.cs
@@ -15,7 +15,7 @@ public class PlayerInteractScript : MonoBehaviour {
             return;
 
         if (interactAction != null && interactAction.triggered) {
-            Debug.Log("called");
+            // Debug.Log("called");
             float interactRange = 2f;
             Collider[] colliderArray = Physics.OverlapSphere(
                 transform.position,


### PR DESCRIPTION
## Summary
- display loop counter in UI and increment after each loop reset
- limit debug output to item pickup, knowledge gain, quest updates, and murder attempt completion
- remove numerous debug logs and stray comments

## Testing
- ⚠️ no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ab38d83af883308fc50e03fce4b315