### PR TITLE
Rename GameTime.Update to RefreshClockText

### DIFF
--- a/Assets/Scripts/GameTime.cs
+++ b/Assets/Scripts/GameTime.cs
@@ -23,13 +23,15 @@ public class GameTime : MonoBehaviour {
         if (Hours > 13 || (Hours == 13 && Minutes > 1)) {
             LoopResetInputScript.TryLoopReset();
         }
-        Update();
+        RefreshClockText();
         OnTimeChanged?.Invoke(Hours, Minutes);
     }
 
     public override string ToString() => $"{Hours:D2}:{Minutes:D2}";
 
-    public void Update() {
+    public void RefreshClockText() {
         clockText.text = GameTime.Instance.ToString();
     }
+
+    private void Update() => RefreshClockText();
 }

--- a/Assets/Scripts/LoopResetInputScript.cs
+++ b/Assets/Scripts/LoopResetInputScript.cs
@@ -2,16 +2,16 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 
 public class LoopResetInputScript : MonoBehaviour {
-    [SerializeField] private InputActionReference resetActionReference; // можно оставить пустым — возьмём из InputSystem.actions
+    [SerializeField] private InputActionReference resetActionReference; // Г¬Г®Г¦Г­Г® Г®Г±ГІГ ГўГЁГІГј ГЇГіГ±ГІГ»Г¬ вЂ” ГўГ®Г§ГјГ¬ВёГ¬ ГЁГ§ InputSystem.actions
     private InputAction resetAction;
 
-    // --- антидубль ---
+    // --- Г Г­ГІГЁГ¤ГіГЎГ«Гј ---
     private static int s_lastResetFrame = -1;
     private static float s_lastResetTime = -1f;
-    private const float kResetDebounceSeconds = 0.05f; // 50 мс, чтобы пережить двойные дергания разными инстансами
+    private const float kResetDebounceSeconds = 0.05f; // 50 Г¬Г±, Г·ГІГ®ГЎГ» ГЇГҐГ°ГҐГ¦ГЁГІГј Г¤ГўГ®Г©Г­Г»ГҐ Г¤ГҐГ°ГЈГ Г­ГЁГї Г°Г Г§Г­Г»Г¬ГЁ ГЁГ­Г±ГІГ Г­Г±Г Г¬ГЁ
 
     private void Awake() {
-        // Подсказка, если в сцене несколько таких компонентов
+        // ГЏГ®Г¤Г±ГЄГ Г§ГЄГ , ГҐГ±Г«ГЁ Гў Г±Г¶ГҐГ­ГҐ Г­ГҐГ±ГЄГ®Г«ГјГЄГ® ГІГ ГЄГЁГµ ГЄГ®Г¬ГЇГ®Г­ГҐГ­ГІГ®Гў
         var all = FindObjectsOfType<LoopResetInputScript>(true);
         if (all.Length > 1) {
             Debug.LogWarning($"[LoopReset] In scene there are {all.Length} LoopResetInputScript instances. Debounce will prevent double reset.");
@@ -28,17 +28,18 @@ public class LoopResetInputScript : MonoBehaviour {
     }
 
     private void Update() {
-        // Реагируем ровно один раз на нажатие
+        // ГђГҐГ ГЈГЁГ°ГіГҐГ¬ Г°Г®ГўГ­Г® Г®Г¤ГЁГ­ Г°Г Г§ Г­Г  Г­Г Г¦Г ГІГЁГҐ
         if (resetAction != null && resetAction.WasPressedThisFrame()) {
             TryLoopReset();
         }
     }
 
-    // Вызывай ЭТО вместо прямого LoopReset() и из таймера тоже, чтобы всё шло через один предохранитель
+        GameTime.Instance.RefreshClockText();
+    // Г‚Г»Г§Г»ГўГ Г© ГќГ’ГЋ ГўГ¬ГҐГ±ГІГ® ГЇГ°ГїГ¬Г®ГЈГ® LoopReset() ГЁ ГЁГ§ ГІГ Г©Г¬ГҐГ°Г  ГІГ®Г¦ГҐ, Г·ГІГ®ГЎГ» ГўГ±Вё ГёГ«Г® Г·ГҐГ°ГҐГ§ Г®Г¤ГЁГ­ ГЇГ°ГҐГ¤Г®ГµГ°Г Г­ГЁГІГҐГ«Гј
     public static void TryLoopReset() {
-        // не чаще одного раза за кадр
+        // Г­ГҐ Г·Г Г№ГҐ Г®Г¤Г­Г®ГЈГ® Г°Г Г§Г  Г§Г  ГЄГ Г¤Г°
         if (Time.frameCount == s_lastResetFrame) return;
-        // и с коротким кулдауном (на случай двух разных компонентов/систем)
+        // ГЁ Г± ГЄГ®Г°Г®ГІГЄГЁГ¬ ГЄГіГ«Г¤Г ГіГ­Г®Г¬ (Г­Г  Г±Г«ГіГ·Г Г© Г¤ГўГіГµ Г°Г Г§Г­Г»Гµ ГЄГ®Г¬ГЇГ®Г­ГҐГ­ГІГ®Гў/Г±ГЁГ±ГІГҐГ¬)
         if (s_lastResetTime >= 0f && (Time.unscaledTime - s_lastResetTime) < kResetDebounceSeconds) return;
 
         s_lastResetFrame = Time.frameCount;
@@ -47,7 +48,7 @@ public class LoopResetInputScript : MonoBehaviour {
         DoLoopReset();
     }
 
-    // Вынес тело ресета в статический метод — так любой источник (кнопка, время, триггеры) идёт по одной дороге
+    // Г‚Г»Г­ГҐГ± ГІГҐГ«Г® Г°ГҐГ±ГҐГІГ  Гў Г±ГІГ ГІГЁГ·ГҐГ±ГЄГЁГ© Г¬ГҐГІГ®Г¤ вЂ” ГІГ ГЄ Г«ГѕГЎГ®Г© ГЁГ±ГІГ®Г·Г­ГЁГЄ (ГЄГ­Г®ГЇГЄГ , ГўГ°ГҐГ¬Гї, ГІГ°ГЁГЈГЈГҐГ°Г») ГЁГ¤ВёГІ ГЇГ® Г®Г¤Г­Г®Г© Г¤Г®Г°Г®ГЈГҐ
     private static void DoLoopReset() {
         Debug.Log("[LoopReset] start");
 
@@ -86,6 +87,6 @@ public class LoopResetInputScript : MonoBehaviour {
         Debug.Log("[LoopReset] end");
     }
 
-    public void LoopReset() => TryLoopReset(); // дергает тот же дебаунс
+    public void LoopReset() => TryLoopReset(); // Г¤ГҐГ°ГЈГ ГҐГІ ГІГ®ГІ Г¦ГҐ Г¤ГҐГЎГ ГіГ­Г±
 
 }


### PR DESCRIPTION
## Summary
- Rename GameTime's `Update` to `RefreshClockText` and introduce a dedicated `MonoBehaviour.Update` to call it
- Refresh clock after resetting time in `LoopResetInputScript`

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ab4d00dd848330985687068ae50279