### PR TITLE
Sync player stats with Articy variables

### DIFF
--- a/Assets/Scripts/LoopCounter.cs
+++ b/Assets/Scripts/LoopCounter.cs
@@ -1,5 +1,6 @@
 using TMPro;
 using UnityEngine;
+using Articy.World_Of_Red_Moon.GlobalVariables;
 
 public class LoopCounter : MonoBehaviour, ILoopResettable
 {
@@ -17,11 +18,13 @@ public class LoopCounter : MonoBehaviour, ILoopResettable
     void Start()
     {
         UpdateText();
+        ArticyGlobalVariables.Default.PS.loopCounter = Count;
     }
 
     public void OnLoopReset()
     {
         Count++;
+        ArticyGlobalVariables.Default.PS.loopCounter = Count;
         UpdateText();
     }
 

--- a/Assets/Scripts/PlayerState.cs
+++ b/Assets/Scripts/PlayerState.cs
@@ -1,13 +1,37 @@
 using System.Collections.Generic;
+using Articy.World_Of_Red_Moon.GlobalVariables;
 
 public struct PlayerState {
     public HashSet<string> Knowledge;
     public bool hasArtifact;
     public bool hasGun;
 
-    public PlayerState(HashSet<string> knowledge = null, bool hasArtifact = false, bool hasGun = false) {
+    private int _skillPersuasion;
+    private int _skillPerseption;
+
+    public int skillPersuasion {
+        get => _skillPersuasion;
+        set {
+            _skillPersuasion = value;
+            ArticyGlobalVariables.Default.PS.skill_Persuasion = value;
+        }
+    }
+
+    public int skillPerseption {
+        get => _skillPerseption;
+        set {
+            _skillPerseption = value;
+            ArticyGlobalVariables.Default.PS.skill_Perseption = value;
+        }
+    }
+
+    public PlayerState(HashSet<string> knowledge = null, bool hasArtifact = false, bool hasGun = false, int skillPersuasion = 0, int skillPerseption = 0) {
         Knowledge = knowledge ?? new HashSet<string>();
         this.hasArtifact = hasArtifact;
         this.hasGun = hasGun;
+        _skillPersuasion = skillPersuasion;
+        _skillPerseption = skillPerseption;
+        ArticyGlobalVariables.Default.PS.skill_Persuasion = skillPersuasion;
+        ArticyGlobalVariables.Default.PS.skill_Perseption = skillPerseption;
     }
 }


### PR DESCRIPTION
## Summary
- update loop counter to synchronize Articy PS.loopCounter
- add persuasion and perception skills to PlayerState with automatic Articy sync

No tests were run per user request.

------
https://chatgpt.com/codex/tasks/task_e_68ac22fddf488330b854419a746df4fa