### PR TITLE
Use Skill objects for player abilities

### DIFF
--- a/Assets/Scripts/GlobalVariables.cs
+++ b/Assets/Scripts/GlobalVariables.cs
@@ -30,8 +30,9 @@ public class GlobalVariables : MonoBehaviour {
             return;
         }
         Instance = this;
-        player.skillPerseption = 10;
-        player.skillPersuasion = 10;
+        player = new PlayerState();
+        player.skillPerseption.Value = 10;
+        player.skillPersuasion.Value = 10;
 
         if (!setOfKnowledge) setOfKnowledge = GetComponent<TMP_Text>();
 

--- a/Assets/Scripts/PlayerState.cs
+++ b/Assets/Scripts/PlayerState.cs
@@ -1,37 +1,19 @@
 using System.Collections.Generic;
-using Articy.World_Of_Red_Moon.GlobalVariables;
+
 
 public struct PlayerState {
     public HashSet<string> Knowledge;
     public bool hasArtifact;
     public bool hasGun;
 
-    private int _skillPersuasion;
-    private int _skillPerseption;
+    public Skill skillPersuasion;
+    public Skill skillPerseption;
 
-    public int skillPersuasion {
-        get => _skillPersuasion;
-        set {
-            _skillPersuasion = value;
-            ArticyGlobalVariables.Default.PS.skill_Persuasion = value;
-        }
-    }
-
-    public int skillPerseption {
-        get => _skillPerseption;
-        set {
-            _skillPerseption = value;
-            ArticyGlobalVariables.Default.PS.skill_Perseption = value;
-        }
-    }
-
-    public PlayerState(HashSet<string> knowledge = null, bool hasArtifact = false, bool hasGun = false, int skillPersuasion = 0, int skillPerseption = 0) {
+    public PlayerState(HashSet<string> knowledge = null, bool hasArtifact = false, bool hasGun = false) {
         Knowledge = knowledge ?? new HashSet<string>();
         this.hasArtifact = hasArtifact;
         this.hasGun = hasGun;
-        _skillPersuasion = skillPersuasion;
-        _skillPerseption = skillPerseption;
-        ArticyGlobalVariables.Default.PS.skill_Persuasion = skillPersuasion;
-        ArticyGlobalVariables.Default.PS.skill_Perseption = skillPerseption;
+        skillPersuasion = new Skill("Persuasion");
+        skillPerseption = new Skill("Perseption");
     }
 }

--- a/Assets/Scripts/Skill.cs
+++ b/Assets/Scripts/Skill.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using Articy.World_Of_Red_Moon.GlobalVariables;
+
+public class Skill {
+    private readonly string _name;
+    private readonly PropertyInfo _articyVar;
+    private int _value;
+
+    public Skill(string name) {
+        _name = name;
+        var gv = ArticyGlobalVariables.Default.PS;
+        _articyVar = gv.GetType().GetProperty($"skill_{name}");
+        if (_articyVar != null) {
+            _value = (int)_articyVar.GetValue(gv);
+        } else {
+            _value = 42;
+        }
+    }
+
+    public int Value {
+        get => _value;
+        set {
+            _value = value;
+            if (_articyVar != null) {
+                _articyVar.SetValue(ArticyGlobalVariables.Default.PS, value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Wrap player skill values in a new `Skill` class that syncs with Articy global variables and defaults to 42 if no matching variable exists
- Refactor `PlayerState` to store `Skill` objects and initialize them consistently
- Update global variables initialization to use the new `Skill` abstraction

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5620f1b483308e595a76e0094773