### PR TITLE
Add startup skill selection window

### DIFF
--- a/Assets/Scripts/GlobalVariables.cs
+++ b/Assets/Scripts/GlobalVariables.cs
@@ -31,8 +31,10 @@ public class GlobalVariables : MonoBehaviour {
         }
         Instance = this;
         player = new PlayerState(null, false, false);
-        player.skillPerseption.Value = 5;
-        player.skillPersuasion.Value = 5;
+
+        var selector = FindObjectOfType<SkillSelectionUI>();
+        if (selector)
+            selector.Open(player);
 
         if (!setOfKnowledge) setOfKnowledge = GetComponent<TMP_Text>();
 

--- a/Assets/Scripts/SkillSelectionUI.cs
+++ b/Assets/Scripts/SkillSelectionUI.cs
@@ -1,0 +1,86 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+public class SkillSelectionUI : MonoBehaviour {
+    [Serializable]
+    private class SkillSlot {
+        public string fieldName;
+        public TMP_Text nameText;
+        public TMP_Text valueText;
+        public Button plusButton;
+        public Button minusButton;
+        [HideInInspector] public Skill skill;
+        [HideInInspector] public int value;
+    }
+
+    [SerializeField] private SkillSlot[] slots;
+    [SerializeField] private TMP_Text pointsLeftText;
+    [SerializeField] private Button okButton;
+
+    private int pointsLeft;
+    private PlayerState player;
+
+    private void Awake() {
+        gameObject.SetActive(false);
+    }
+
+    public void Open(PlayerState player) {
+        this.player = player;
+        pointsLeft = 10;
+        foreach (var slot in slots) {
+            var field = typeof(PlayerState).GetField(slot.fieldName);
+            if (field != null && field.FieldType == typeof(Skill)) {
+                slot.skill = (Skill)field.GetValue(player);
+                if (slot.nameText)
+                    slot.nameText.text = slot.fieldName;
+            }
+            slot.value = 0;
+            if (slot.valueText)
+                slot.valueText.text = "0";
+            if (slot.plusButton) {
+                slot.plusButton.onClick.RemoveAllListeners();
+                slot.plusButton.onClick.AddListener(() => Change(slot, 1));
+            }
+            if (slot.minusButton) {
+                slot.minusButton.onClick.RemoveAllListeners();
+                slot.minusButton.onClick.AddListener(() => Change(slot, -1));
+            }
+        }
+        UpdateUI();
+        gameObject.SetActive(true);
+    }
+
+    private void Change(SkillSlot slot, int delta) {
+        if (delta > 0 && pointsLeft == 0) return;
+        if (delta < 0 && slot.value == 0) return;
+        slot.value += delta;
+        pointsLeft -= delta;
+        if (slot.valueText)
+            slot.valueText.text = slot.value.ToString();
+        UpdateUI();
+    }
+
+    private void UpdateUI() {
+        if (pointsLeftText)
+            pointsLeftText.text = pointsLeft.ToString();
+        if (okButton)
+            okButton.interactable = pointsLeft == 0;
+        foreach (var slot in slots) {
+            if (slot.minusButton)
+                slot.minusButton.interactable = slot.value > 0;
+            if (slot.plusButton)
+                slot.plusButton.interactable = pointsLeft > 0;
+        }
+    }
+
+    public void Confirm() {
+        if (pointsLeft != 0) return;
+        foreach (var slot in slots) {
+            if (slot.skill != null)
+                slot.skill.Value = slot.value;
+        }
+        gameObject.SetActive(false);
+    }
+}

--- a/Assets/Scripts/SkillSelectionUI.cs.meta
+++ b/Assets/Scripts/SkillSelectionUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d9b41e0a7c0488b8a5deff9d2d1252c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Add SkillSelectionUI to distribute 10 starting skill points among player skills
- Open skill selection window on game start

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ad5fb1374483309d90abfb4898d350