### PR TITLE
Ensure skill selection slots stretch to parent

### DIFF
--- a/Assets/Scripts/SkillSelectionUI.cs
+++ b/Assets/Scripts/SkillSelectionUI.cs
@@ -30,7 +30,13 @@ public class SkillSelectionUI : MonoBehaviour {
             var go = new GameObject("Slots", typeof(RectTransform), typeof(VerticalLayoutGroup));
             slotContainer = go.GetComponent<RectTransform>();
             slotContainer.SetParent(transform, false);
+            slotContainer.anchorMin = Vector2.zero;
+            slotContainer.anchorMax = Vector2.one;
+            slotContainer.offsetMin = Vector2.zero;
+            slotContainer.offsetMax = Vector2.zero;
             slotContainer.SetSiblingIndex(0);
+            if (transform.GetComponent<LayoutGroup>() && !slotContainer.GetComponent<LayoutElement>())
+                slotContainer.gameObject.AddComponent<LayoutElement>();
             var layout = slotContainer.GetComponent<VerticalLayoutGroup>();
             layout.childControlHeight = true;
             layout.childControlWidth = true;


### PR DESCRIPTION
## Summary
- Stretch slot container to fill parent in `SkillSelectionUI.Awake`
- Reset slot container offsets and add optional `LayoutElement` when parent uses a `LayoutGroup`

## Testing
- ⚠️ No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ad96fe137c833080d84da988e6f3d5