### PR TITLE
Use runtime-safe sprite for SkillSelectionUI buttons

### DIFF
--- a/Assets/Scripts/SkillSelectionUI.cs
+++ b/Assets/Scripts/SkillSelectionUI.cs
@@ -138,7 +138,10 @@ public class SkillSelectionUI : MonoBehaviour {
         var btnObj = new GameObject(label, typeof(RectTransform), typeof(Image), typeof(Button));
         btnObj.transform.SetParent(parent, false);
         var img = btnObj.GetComponent<Image>();
-        img.sprite = Resources.GetBuiltinResource<Sprite>("UI/Skin/UISprite.psd");
+        var sprite = Sprite.Create(Texture2D.whiteTexture, new Rect(0f, 0f, 1f, 1f), new Vector2(0.5f, 0.5f));
+        img.sprite = sprite;
+        img.type = Image.Type.Sliced;
+        img.color = Color.gray;
 
         var textObj = new GameObject("Text", typeof(RectTransform), typeof(TextMeshProUGUI));
         textObj.transform.SetParent(btnObj.transform, false);


### PR DESCRIPTION
## Summary
- Create 1x1 white sprite from `Texture2D.whiteTexture` instead of relying on builtin resources
- Tint button image gray and set sliced type for consistent appearance

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ad98315f6c8330b65145b14cbe3077