### PR TITLE
Fix SkillSelectionUI buttons not clickable

### DIFF
--- a/Assets/Scripts/SkillSelectionUI.cs
+++ b/Assets/Scripts/SkillSelectionUI.cs
@@ -148,6 +148,7 @@ public class SkillSelectionUI : MonoBehaviour {
         var txt = textObj.GetComponent<TextMeshProUGUI>();
         txt.text = label;
         txt.alignment = TextAlignmentOptions.Center;
+        txt.raycastTarget = false;
 
         var rect = txt.rectTransform;
         rect.anchorMin = Vector2.zero;


### PR DESCRIPTION
## Summary
- Prevent SkillSelectionUI text objects from intercepting pointer events so +/- buttons are clickable

## Testing
- `mcs Assets/Scripts/SkillSelectionUI.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad996d4a908330905af7bb0c2acbb6