### PR TITLE
Add player stats display script

### DIFF
--- a/Assets/Scripts/PlayerStatsDisplay.cs
+++ b/Assets/Scripts/PlayerStatsDisplay.cs
@@ -1,0 +1,29 @@
+using TMPro;
+using UnityEngine;
+using Articy.World_Of_Red_Moon.GlobalVariables;
+
+public class PlayerStatsDisplay : MonoBehaviour {
+    [SerializeField] private TMP_Text targetText;
+
+    private void Awake() {
+        if (targetText == null)
+            targetText = GetComponent<TMP_Text>();
+    }
+
+    private void Update() {
+        if (targetText == null || GlobalVariables.Instance == null)
+            return;
+
+        var player = GlobalVariables.Instance.player;
+        int loopState = ArticyGlobalVariables.Default.PS.loopCounter;
+
+        targetText.text =
+            $"Moral: {player.moralVal}/{player.moralCap}\n" +
+            $"Loop: {loopState}\n" +
+            "Skills:\n" +
+            $"  Persuasion: {player.skillPersuasion.Value}\n" +
+            $"  Perception: {player.skillPerseption.Value}\n" +
+            $"  Accuracy: {player.skillAccuracy.Value}";
+    }
+}
+

--- a/Assets/Scripts/PlayerStatsDisplay.cs.meta
+++ b/Assets/Scripts/PlayerStatsDisplay.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d99860bf1181476286eec50f0bad9d88


### PR DESCRIPTION
## Summary
- add TMP text component script to show player's moral values, loop counter, and skills

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68af050b749c833084b07c1eca5c686d