### PR TITLE
Clamp moral values and trigger GameOver when cap depleted

### DIFF
--- a/Assets/Scripts/GameOver.cs
+++ b/Assets/Scripts/GameOver.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+public static class GameOver
+{
+    public static void Trigger()
+    {
+        LoopResetInputScript.TryLoopReset();
+        Debug.Log("Game Over");
+    }
+}
+

--- a/Assets/Scripts/GlobalVariables.cs
+++ b/Assets/Scripts/GlobalVariables.cs
@@ -179,24 +179,48 @@ public class GlobalVariables : MonoBehaviour {
         var articyMoralVal = ArticyGlobalVariables.Default.PS.moralVal;
         if (articyMoralVal != lastArticyMoralVal) {
             player.moralVal = articyMoralVal;
-            lastArticyMoralVal = articyMoralVal;
+            if (player.moralVal > player.moralCap) {
+                player.moralVal = player.moralCap;
+                ArticyGlobalVariables.Default.PS.moralVal = player.moralVal;
+            }
+            lastArticyMoralVal = player.moralVal;
             lastPlayerMoralVal = player.moralVal;
         }
 
         var articyMoralCap = ArticyGlobalVariables.Default.PS.moralCap;
         if (articyMoralCap != lastArticyMoralCap) {
             player.moralCap = articyMoralCap;
+            if (player.moralCap <= 0) {
+                GameOver.Trigger();
+            }
+            if (player.moralVal > player.moralCap) {
+                player.moralVal = player.moralCap;
+                ArticyGlobalVariables.Default.PS.moralVal = player.moralVal;
+                lastArticyMoralVal = player.moralVal;
+                lastPlayerMoralVal = player.moralVal;
+            }
             lastArticyMoralCap = articyMoralCap;
             lastPlayerMoralCap = player.moralCap;
         }
 
         if (player.moralVal != lastPlayerMoralVal) {
+            if (player.moralVal > player.moralCap)
+                player.moralVal = player.moralCap;
             ArticyGlobalVariables.Default.PS.moralVal = player.moralVal;
             lastPlayerMoralVal = player.moralVal;
             lastArticyMoralVal = player.moralVal;
         }
 
         if (player.moralCap != lastPlayerMoralCap) {
+            if (player.moralCap <= 0) {
+                GameOver.Trigger();
+            }
+            if (player.moralVal > player.moralCap) {
+                player.moralVal = player.moralCap;
+                ArticyGlobalVariables.Default.PS.moralVal = player.moralVal;
+                lastPlayerMoralVal = player.moralVal;
+                lastArticyMoralVal = player.moralVal;
+            }
             ArticyGlobalVariables.Default.PS.moralCap = player.moralCap;
             lastPlayerMoralCap = player.moralCap;
             lastArticyMoralCap = player.moralCap;


### PR DESCRIPTION
## Summary
- Clamp `moralVal` to `moralCap` whenever it changes
- Trigger loop reset via new `GameOver` utility when moral cap falls to zero or below

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af35e924cc8330937e8253b8beeb80