### PR TITLE
feat: add global player input blocker

### DIFF
--- a/Assets/Scripts/DialogueSystem/DialogueUI.cs
+++ b/Assets/Scripts/DialogueSystem/DialogueUI.cs
@@ -145,7 +145,7 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
         // Задаём стартовую точку и не проигрываем первый узел автоматически
         flowPlayer.StartOn = startFragment;
         IsDialogueOpen = true;
-
+        PlayerInputBlocker.Block();
     }
 
     /// <summary>Принудительно закрыть текущий диалог (например, кнопкой "Esc").</summary>
@@ -154,6 +154,7 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
         dialogueFinished = false;
         responseHandler?.ClearResponses();
         IsDialogueOpen = false;
+        PlayerInputBlocker.Unblock();
         if (flowPlayer != null) {
             SetContinuousRecalculation(originalRecalcSetting ?? false);
             suppressOnFlowPause = true;

--- a/Assets/Scripts/PlayerInputBlocker.cs
+++ b/Assets/Scripts/PlayerInputBlocker.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using UnityEngine.InputSystem;
+
+/// <summary>
+/// Provides a universal way to temporarily block all player input actions.
+/// </summary>
+public static class PlayerInputBlocker
+{
+    private static int _blockCounter = 0;
+    private static readonly HashSet<InputActionMap> _disabledMaps = new();
+    private static readonly List<InputAction> _scratchActions = new();
+
+    /// <summary>
+    /// Disable all currently enabled input actions. Supports nested blocking.
+    /// </summary>
+    public static void Block()
+    {
+        _blockCounter++;
+        if (_blockCounter == 1)
+        {
+            _disabledMaps.Clear();
+            _scratchActions.Clear();
+            InputSystem.ListEnabledActions(_scratchActions);
+
+            foreach (var action in _scratchActions)
+            {
+                var map = action.actionMap;
+                if (map == null || map.name == "UI")
+                    continue;
+
+                if (_disabledMaps.Add(map))
+                    map.Disable();
+            }
+            _scratchActions.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Re-enable input actions when no blockers remain.
+    /// </summary>
+    public static void Unblock()
+    {
+        if (_blockCounter == 0)
+            return;
+
+        _blockCounter--;
+        if (_blockCounter == 0)
+        {
+            foreach (var map in _disabledMaps)
+            {
+                map.Enable();
+            }
+            _disabledMaps.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Returns true if player input is currently blocked.
+    /// </summary>
+    public static bool IsBlocked => _blockCounter > 0;
+}
+

--- a/Assets/Scripts/PlayerInteractScript.cs
+++ b/Assets/Scripts/PlayerInteractScript.cs
@@ -3,15 +3,13 @@ using UnityEngine.InputSystem;
 
 public class PlayerInteractScript : MonoBehaviour {
     InputAction interactAction;
-    private DialogueUI dialogueUI;
 
     void Start() {
         interactAction = InputSystem.actions.FindAction("Interact");
-        dialogueUI = FindObjectOfType<DialogueUI>();
     }
 
     void Update() {
-        if (dialogueUI != null && dialogueUI.IsDialogueOpen)
+        if (PlayerInputBlocker.IsBlocked)
             return;
 
         if (interactAction != null && interactAction.triggered) {

--- a/Assets/Scripts/PlayerMovementScript.cs
+++ b/Assets/Scripts/PlayerMovementScript.cs
@@ -5,15 +5,13 @@ public class PlayerMovementScript : MonoBehaviour {
     InputAction moveAction;
     public Rigidbody rb;
     public float movementSpeed = 5;
-    private DialogueUI dialogueUI;
 
     void Start() {
         moveAction = InputSystem.actions.FindAction("Move");
-        dialogueUI = FindObjectOfType<DialogueUI>();
     }
 
     void Update() {
-        if (dialogueUI != null && dialogueUI.IsDialogueOpen) {
+        if (PlayerInputBlocker.IsBlocked) {
             rb.linearVelocity = Vector3.zero;
             return;
         }

--- a/Assets/Scripts/SkillSelectionUI.cs
+++ b/Assets/Scripts/SkillSelectionUI.cs
@@ -43,7 +43,11 @@ public class SkillSelectionUI : MonoBehaviour {
     }
 
     private void OnEnable() { Debug.Log("[SkillSelectionUI] OnEnable"); }
-    private void OnDisable() { Debug.Log("[SkillSelectionUI] OnDisable"); }
+    private void OnDisable()
+    {
+        Debug.Log("[SkillSelectionUI] OnDisable");
+        PlayerInputBlocker.Unblock();
+    }
 
     private void EnsureSetup() {
         if (_setupDone) return;
@@ -135,6 +139,7 @@ public class SkillSelectionUI : MonoBehaviour {
         ShowImmediate();                    // ← только CanvasGroup
         transform.SetAsLastSibling();       // поверх соседей
         Canvas.ForceUpdateCanvases();
+        PlayerInputBlocker.Block();
 
         Debug.Log($"[SkillSelectionUI] Open: slots={_slots.Count}, pointsLeft={pointsLeft}, activeSelf={gameObject.activeSelf}, inHierarchy={gameObject.activeInHierarchy}");
     }
@@ -223,6 +228,7 @@ public class SkillSelectionUI : MonoBehaviour {
                 s.skill.Value = s.value; // или += s.value
         }
         HideImmediate(); // только прячем, не выключаем GO
+        PlayerInputBlocker.Unblock();
         Debug.Log("[SkillSelectionUI] Confirm → apply & hide (CG)");
     }
 


### PR DESCRIPTION
## Summary
- centralize input blocking via PlayerInputBlocker
- disable and restore action maps to reinstate movement after blocking
- use PlayerInputBlocker for dialogue, skill UI, and player scripts
- keep UI actions responsive during input blocking
- unblock controls when skill selection UI closes even if not confirmed

## Testing
- ⚠️ no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68b5dacc07388330a5de31f7ba28c49c