### PR TITLE
Handle Articy identification flag

### DIFF
--- a/Assets/Scripts/GlobalVariables.cs
+++ b/Assets/Scripts/GlobalVariables.cs
@@ -230,5 +230,14 @@ public class GlobalVariables : MonoBehaviour {
         }
 
         ResolveSkillChecks();
+
+        // Reflectively check for the Articy flag RFLG.kotIdentify. If it's set, reset it
+        // and mark all inventory items as identified.
+        var rflgObj = typeof(ArticyGlobalVariables).GetProperty("RFLG")?.GetValue(ArticyGlobalVariables.Default);
+        var kotIdentifyProp = rflgObj?.GetType().GetProperty("kotIdentify");
+        if (kotIdentifyProp != null && kotIdentifyProp.GetValue(rflgObj) is bool flag && flag) {
+            kotIdentifyProp.SetValue(rflgObj, false);
+            InventoryStorage.IdentifyAll();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Track identified inventory items and provide an `IdentifyAll` helper
- Reset Articy `RFLG.kotIdentify` flag via reflection and mark inventory items identified

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68b7f38fcc08833089aa7c61bf1ab1eb