### PR TITLE
Add clue score total and display

### DIFF
--- a/Assets/Scripts/ClueTotalScoreDisplay.cs
+++ b/Assets/Scripts/ClueTotalScoreDisplay.cs
@@ -1,0 +1,20 @@
+using TMPro;
+using UnityEngine;
+
+/// <summary>
+/// Displays the total clue score on a TextMeshPro component.
+/// </summary>
+public class ClueTotalScoreDisplay : MonoBehaviour {
+    [SerializeField] private TMP_Text targetText;
+
+    private void Awake() {
+        if (targetText == null)
+            targetText = GetComponent<TMP_Text>();
+    }
+
+    private void Update() {
+        if (targetText == null)
+            return;
+        targetText.text = $"Clue Score: {InventoryStorage.ClueTotalScore:F1}";
+    }
+}

--- a/Assets/Scripts/Inventory/InventoryStorage.cs
+++ b/Assets/Scripts/Inventory/InventoryStorage.cs
@@ -101,6 +101,23 @@ public static class InventoryStorage {
             return new Item(kvp.Key, kvp.Value.Count, isClue: isClue, isIdentified: isIdentified, clueScore: value);
         }).ToList();
 
+    /// <summary>
+    /// Calculates the total clue score based on items currently in the inventory.
+    /// Unidentified clues are counted as 0.5 points.
+    /// </summary>
+    public static float ClueTotalScore {
+        get {
+            float total = 0f;
+            foreach (var kvp in _items) {
+                if (ArticyClueSync.TryGetClueValue(kvp.Key, out var value)) {
+                    bool identified = _identifiedItems.Contains(kvp.Key);
+                    total += identified ? value : 0.5f;
+                }
+            }
+            return total;
+        }
+    }
+
     public static int GetCount(string technicalName) =>
         _items.TryGetValue(technicalName, out var set) ? set.Count : 0;
 


### PR DESCRIPTION
## Summary
- compute total clue score from inventory, treating unidentified clues as 0.5 points
- add TextMeshPro display for the overall clue score

No tests were run per user request.

------
https://chatgpt.com/codex/tasks/task_e_68b7f50b14308330b7d7cda69d726bd9