### PR TITLE
feat(interactions): keep door trigger active

### DIFF
--- a/Assets/Scripts/Interactions/DoorInteractable.cs
+++ b/Assets/Scripts/Interactions/DoorInteractable.cs
@@ -5,16 +5,36 @@ public class DoorInteractable : MonoBehaviour, IInteractable, ILoopResettable
     [SerializeField] private bool isLocked;
     [SerializeField] private bool isOpen;
     [SerializeField] private GameObject doorObject;
+    [SerializeField] private Collider interactionTrigger;
 
+    private MeshRenderer doorRenderer;
+    private Collider doorCollider;
     private bool startIsOpen;
+    private bool startDoorColliderEnabled;
+    private bool startInteractionTriggerEnabled;
 
     private void Awake()
     {
         if (doorObject == null && transform.childCount > 0)
             doorObject = transform.GetChild(0).gameObject;
 
+        if (doorObject != null)
+        {
+            doorRenderer = doorObject.GetComponent<MeshRenderer>();
+            doorCollider = doorObject.GetComponent<Collider>();
+        }
+
+        if (interactionTrigger != null)
+        {
+            interactionTrigger.gameObject.SetActive(true);
+            interactionTrigger.isTrigger = true;
+        }
+
         startIsOpen = isOpen;
         ApplyState(isOpen);
+
+        startDoorColliderEnabled = doorCollider != null && doorCollider.enabled;
+        startInteractionTriggerEnabled = interactionTrigger != null && interactionTrigger.enabled;
     }
 
     public void Interact()
@@ -28,13 +48,25 @@ public class DoorInteractable : MonoBehaviour, IInteractable, ILoopResettable
     public void OnLoopReset()
     {
         ApplyState(startIsOpen);
+
+        if (doorCollider != null)
+            doorCollider.enabled = startDoorColliderEnabled;
+
+        if (interactionTrigger != null)
+        {
+            interactionTrigger.enabled = startInteractionTriggerEnabled;
+            interactionTrigger.isTrigger = true;
+        }
     }
 
     private void ApplyState(bool open)
     {
         isOpen = open;
 
-        if (doorObject != null)
-            doorObject.SetActive(!open);
+        if (doorRenderer != null)
+            doorRenderer.enabled = !open;
+
+        if (doorCollider != null)
+            doorCollider.enabled = !open;
     }
 }


### PR DESCRIPTION
## Summary
- keep a separate interaction collider active for DoorInteractable
- disable only visual mesh and blocking collider when door opens
- reset colliders to their starting state on loop reset

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68c2df0f046c8330b515f78aee68b484