### PR TITLE
Add Menu panel toggle on Escape

### DIFF
--- a/Assets/Scripts/MenuToggle.cs
+++ b/Assets/Scripts/MenuToggle.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class MenuToggle : MonoBehaviour {
+    [SerializeField] private GameObject menuPanel;
+    private InputAction escapeAction;
+
+    private void Start() {
+        escapeAction = InputSystem.actions.FindAction("Escape");
+        if (menuPanel == null) {
+            var found = GameObject.Find("Menu");
+            if (found != null) {
+                menuPanel = found;
+            }
+        }
+    }
+
+    private void Update() {
+        if (escapeAction == null)
+            return;
+
+        if (escapeAction.triggered) {
+            ToggleMenu();
+        }
+    }
+
+    private void ToggleMenu() {
+        if (menuPanel == null)
+            return;
+
+        bool newState = !menuPanel.activeSelf;
+        menuPanel.SetActive(newState);
+        if (newState) {
+            menuPanel.transform.SetAsLastSibling();
+        }
+    }
+}

--- a/Assets/Scripts/MenuToggle.cs.meta
+++ b/Assets/Scripts/MenuToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: afb03d37-0e5b-4ff9-a3da-4c4f3f5b640d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Add MenuToggle component to open or close the Menu panel with the Escape action
- Ensure the Menu panel appears above other UI by setting it as last sibling on open

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68c3d5339db8833089b2d00035659a9c