### PR TITLE
fix(dialogue): scroll to bottom on response selection

### DIFF
--- a/Assets/Scripts/DialogueSystem/ResponseHandler.cs
+++ b/Assets/Scripts/DialogueSystem/ResponseHandler.cs
@@ -55,10 +55,15 @@ public class ResponseHandler : MonoBehaviour {
         var btnComponent = buttonObj.GetComponent<Button>();
         if (btnComponent != null) {
             btnComponent.onClick.RemoveAllListeners();
-            if (branch != null)
-                btnComponent.onClick.AddListener(() => flowPlayer.Play(branch));
-            else
-                btnComponent.onClick.AddListener(() => flowPlayer.Play());
+            btnComponent.onClick.AddListener(() => {
+                if (branch != null)
+                    flowPlayer.Play(branch);
+                else
+                    flowPlayer.Play();
+
+                if (scrollbar != null)
+                    scrollbar.value = 0f;
+            });
         }
 
         tempResponseButtons.Add(buttonObj);
@@ -113,6 +118,10 @@ public class ResponseHandler : MonoBehaviour {
 
         if (flowPlayer != null && branch != null)
             flowPlayer.Play(branch);
+
+        if (scrollbar != null)
+            scrollbar.value = 0f;
+
         Debug.Log("picked");
     }
 


### PR DESCRIPTION
## Summary
- Scroll dialogue text to bottom after choosing responses or pressing Next

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68c6950914b483308a3c514b05db822d