### PR TITLE
feat(dialogue): activate continue button

### DIFF
--- a/Assets/Scripts/DialogueSystem/DialogueUI.cs
+++ b/Assets/Scripts/DialogueSystem/DialogueUI.cs
@@ -272,7 +272,7 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
             if (otherBranches.Count == 1) {
                 // ЕДИНСТВЕННАЯ NPC-ветка: НЕ проигрываем автоматически.
                 // Показываем кнопку "Далее" и ждём подтверждения.
-                responseHandler?.CreateSingleResponse("Далее", otherBranches[0], flowPlayer);
+                responseHandler?.ShowContinueButton(otherBranches[0], flowPlayer);
                 dialogueFinished = false;
             } else if (otherBranches.Count > 1) {
                 // Несколько не-игровых веток — можно показать как варианты

--- a/Assets/Scripts/DialogueSystem/ResponseHandler.cs
+++ b/Assets/Scripts/DialogueSystem/ResponseHandler.cs
@@ -18,6 +18,11 @@ public class ResponseHandler : MonoBehaviour {
 
     private List<GameObject> tempResponseButtons = new List<GameObject>();
 
+    private void Awake() {
+        if (continueButton != null)
+            continueButton.gameObject.SetActive(false);
+    }
+
     public void ShowResponses(IList<Branch> branches, ArticyFlowPlayer flowPlayer, Entity playerEntity = null) {
         if (branches == null || flowPlayer == null) return;
 
@@ -89,6 +94,33 @@ public class ResponseHandler : MonoBehaviour {
 
         if (responseBox != null)
             responseBox.gameObject.SetActive(false);
+
+        if (continueButton != null)
+            continueButton.gameObject.SetActive(false);
+    }
+
+    public void ShowContinueButton(Branch branch, ArticyFlowPlayer flowPlayer) {
+        if (continueButton == null || flowPlayer == null) return;
+
+        ClearResponses();
+
+        continueButton.gameObject.SetActive(true);
+        continueButton.onClick.RemoveAllListeners();
+        continueButton.onClick.AddListener(() => {
+            continueButton.gameObject.SetActive(false);
+            if (branch != null)
+                flowPlayer.Play(branch);
+            else
+                flowPlayer.Play();
+
+            if (scrollbar != null) {
+                Canvas.ForceUpdateCanvases();
+                scrollrect.verticalNormalizedPosition = 0f;
+                scrollbar.value = 0f;
+                Debug.Log("scrollbar val changed");
+                Canvas.ForceUpdateCanvases();
+            }
+        });
     }
 
     // --- Âíóòðåííèå âñïîìîãàòåëüíûå ìåòîäû ---


### PR DESCRIPTION
## Summary
- use dedicated Continue button instead of spawning "Next" response
- hide Continue button on dialogue start and after pressing

## Testing
- No tests run (user instruction)


------
https://chatgpt.com/codex/tasks/task_e_68c6c8434f308330aa546700294f5e56