### PR TITLE
feat(dialogue): reload fragment on global variable change

### DIFF
--- a/Assets/Scripts/DialogueSystem/DialogueUI.cs
+++ b/Assets/Scripts/DialogueSystem/DialogueUI.cs
@@ -91,9 +91,7 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
 
             if (currentFlowObject is DialogueFragment fragment)
             {
-                CloseDialogue();
-                StartDialogue(fragment);
-                flowPlayer?.Play();
+                ReloadCurrentFragment(fragment);
             }
         }
     }
@@ -151,6 +149,20 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
         flowPlayer.StartOn = startFragment;
         IsDialogueOpen = true;
 
+    }
+
+    public void ReloadCurrentFragment(DialogueFragment fragment)
+    {
+        if (fragment == null || flowPlayer == null)
+        {
+            Debug.LogWarning("[DialogueUI] ReloadCurrentFragment — null fragment or flowPlayer.");
+            return;
+        }
+
+        flowPlayer.Stop();
+        flowPlayer.ResetState();
+        flowPlayer.JumpTo(fragment);
+        flowPlayer.Play();
     }
 
     //public void UpdateDialogue(bool skipPostClose = false) {


### PR DESCRIPTION
## Summary
- Reload the current dialogue fragment when global variables change
- Add utility to stop, reset, and replay the flow player on the same fragment

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68c6dd8c50248330a9dfa73958fd8a12