### PR TITLE
Restart dialogue next frame when globals change

### DIFF
--- a/Assets/Scripts/DialogueSystem/DialogueUI.cs
+++ b/Assets/Scripts/DialogueSystem/DialogueUI.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
+using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -76,6 +77,14 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
         return false;
     }
 
+    private IEnumerator RestartDialogueNextFrame(DialogueFragment fragment)
+    {
+        CloseDialogue();
+        yield return null;
+        StartDialogue(fragment);
+        flowPlayer.Play();
+    }
+
     private void Update()
     {
       /*  if (!IsDialogueOpen) //something sus going on here
@@ -91,9 +100,7 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
 
             if (currentFlowObject is DialogueFragment fragment)
             {
-                CloseDialogue();
-                StartDialogue(fragment);
-                flowPlayer?.Play();
+                StartCoroutine(RestartDialogueNextFrame(fragment));
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add coroutine to close and restart dialogues on the next frame
- Invoke coroutine when global variables change instead of immediate restart

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68c6e02a600c8330a83ea9d86da11709