### PR TITLE
feat(inventory): display item images

### DIFF
--- a/Assets/Scripts/Inventory/InventoryStorage.cs
+++ b/Assets/Scripts/Inventory/InventoryStorage.cs
@@ -116,7 +116,8 @@ public static class InventoryStorage {
             bool isIdentified = _identifiedItems.Contains(kvp.Key);
             return new Item(kvp.Key, kvp.Value.Count, isClue: isClue, isIdentified: isIdentified, clueScore: value)
             {
-                Description = ItemIds.Descriptions.TryGetValue(kvp.Key, out var desc) ? desc : string.Empty
+                Description = ItemIds.Descriptions.TryGetValue(kvp.Key, out var desc) ? desc : string.Empty,
+                ImagePath = ItemIds.ImagePaths.TryGetValue(kvp.Key, out var img) ? img : string.Empty
             };
         }).ToList();
 

--- a/Assets/Scripts/Inventory/InventoryUI.cs
+++ b/Assets/Scripts/Inventory/InventoryUI.cs
@@ -85,5 +85,12 @@ public class InventoryUI : MonoBehaviour, ILoopResettable
             itemName.text = item?.TechnicalName ?? string.Empty;
         if (itemDescription != null)
             itemDescription.text = item?.Description ?? string.Empty;
+        if (itemPicture != null)
+        {
+            if (item != null && !string.IsNullOrEmpty(item.ImagePath))
+                itemPicture.sprite = Resources.Load<Sprite>(item.ImagePath);
+            else
+                itemPicture.sprite = null;
+        }
     }
 }

--- a/Assets/Scripts/Inventory/Item.cs
+++ b/Assets/Scripts/Inventory/Item.cs
@@ -18,6 +18,8 @@ public class Item
 
     public string Description { get; set; }
 
+    public string ImagePath { get; set; }
+
 
     /// <summary>Creates a new item with the given identifier and count.</summary>
     public Item(string technicalName, int itemCount = 1, bool isClue=false, bool isIdentified=false, float clueScore = 0)

--- a/Assets/Scripts/Inventory/ItemIds.cs
+++ b/Assets/Scripts/Inventory/ItemIds.cs
@@ -29,4 +29,20 @@ public static class ItemIds {
         { VentFiddle, "perplexing fiddle for vents" },
         { EarPressureReports, "reports full of earwig gibberish" }
     };
+
+    public static readonly Dictionary<string, string> ImagePaths = new Dictionary<string, string>
+    {
+        { InventoryArtefact, "Images/InventoryArtefact" },
+        { TestCube, "Images/TestCube" },
+        { JapaneseSweets, "Images/JapaneseSweets" },
+        { Gun, "Images/Gun" },
+        { HarmonicRow, "Images/HarmonicRow" },
+        { SonoceramicShard, "Images/SonoceramicShard" },
+        { SonusGuideTube, "Images/SonusGuideTube" },
+        { ReceiptWhisperer, "Images/ReceiptWhisperer" },
+        { WaxStoppers, "Images/WaxStoppers" },
+        { MaintScrollHum, "Images/MaintScrollHum" },
+        { VentFiddle, "Images/VentFiddle" },
+        { EarPressureReports, "Images/EarPressureReports" }
+    };
 }


### PR DESCRIPTION
## Summary
- add image path data for items
- show item images in Inventory UI when selected

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68c7168e69388330936171e1648ab18e