### PR TITLE
fix: import ReceiptWhisperer texture as sprite

### DIFF
--- a/Assets/Resources/Images/ReceiptWhisperer.png.meta
+++ b/Assets/Resources/Images/ReceiptWhisperer.png.meta
@@ -43,7 +43,7 @@ TextureImporter:
   nPOTScale: 1
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 0
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
@@ -52,9 +52,9 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
-  alphaIsTransparency: 0
+  alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 8
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1


### PR DESCRIPTION
## Summary
- configure ReceiptWhisperer.png to import as a sprite for UI usage

## Testing
- `Unity -batchmode -quit -projectPath . -logFile -` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c71d8940b48330a6abe27d4f090a6b