### PR TITLE
feat(inventory): add small item image and fallback sprite

### DIFF
--- a/Assets/Resources/Images/Black.png
+++ b/Assets/Resources/Images/Black.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c9eb7ed565a3af086dee2cbfb27132f0c052240c6f69b019049399c82fc1df0
+size 207

--- a/Assets/Resources/Images/Black.png.meta
+++ b/Assets/Resources/Images/Black.png.meta
@@ -1,0 +1,117 @@
+fileFormatVersion: 2
+guid: 45caa078d7cd4ea7b9e744f428e2d960
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 4
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    customData: 
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Inventory/InventoryItemUI.cs
+++ b/Assets/Scripts/Inventory/InventoryItemUI.cs
@@ -17,7 +17,7 @@ public class InventoryItemUI : MonoBehaviour
         _inventoryUI = inventoryUI;
         var text = GetComponentInChildren<TMP_Text>();
         if (text != null)
-            text.text = $"{item.TechnicalName} ({item.ItemCount})";
+            text.text = item.ItemCount.ToString();
 
         var button = GetComponent<Button>();
         if (button != null)

--- a/Assets/Scripts/Inventory/InventoryUI.cs
+++ b/Assets/Scripts/Inventory/InventoryUI.cs
@@ -19,6 +19,7 @@ public class InventoryUI : MonoBehaviour, ILoopResettable
     [SerializeField] private Transform itemsParent;
 
     private readonly List<GameObject> _spawnedItems = new List<GameObject>();
+    private const string DefaultImagePath = "Images/Black";
 
     private void Start()
     {
@@ -30,6 +31,7 @@ public class InventoryUI : MonoBehaviour, ILoopResettable
     public void Show()
     {
         Refresh();
+        DisplayItem(null);
         if (inventoryPanel != null)
             inventoryPanel.SetActive(true);
     }
@@ -86,12 +88,16 @@ public class InventoryUI : MonoBehaviour, ILoopResettable
             itemName.text = item?.TechnicalName ?? string.Empty;
         if (itemDescription != null)
             itemDescription.text = item?.Description ?? string.Empty;
+
+        Sprite sprite = null;
+        if (item != null && !string.IsNullOrEmpty(item.ImagePath))
+            sprite = Resources.Load<Sprite>(item.ImagePath);
+        if (sprite == null)
+            sprite = Resources.Load<Sprite>(DefaultImagePath);
+
         if (itemPicture != null)
-        {
-            if (item != null && !string.IsNullOrEmpty(item.ImagePath))
-                itemPicture.sprite = Resources.Load<Sprite>(item.ImagePath);
-            else
-                itemPicture.sprite = null;
-        }
+            itemPicture.sprite = sprite;
+        if (itemPictureSmall != null)
+            itemPictureSmall.sprite = sprite;
     }
 }


### PR DESCRIPTION
## Summary
- populate small item image when showing inventory
- remove item name from inventory buttons
- add black placeholder sprite for missing item images

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68c720ce9ab88330b7edc5d8c2b3e6ae