### PR TITLE
feat: add start sequence flow

### DIFF
--- a/Assets/Scripts/DialogueSystem/DialogueUI.cs
+++ b/Assets/Scripts/DialogueSystem/DialogueUI.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+using System;
+using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 using System.Collections.Generic;
@@ -10,6 +11,9 @@ using Articy.World_Of_Red_Moon;
 using Articy.World_Of_Red_Moon.GlobalVariables;
 
 public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResettable {
+    public event Action<DialogueUI> DialogueStarted;
+    public event Action<DialogueUI> DialogueClosed;
+
     [Header("Articy")]
     [SerializeField] private ArticyFlowPlayer flowPlayer;
     [SerializeField] private Entity playerEntity; // перетащи сюда Entity главного героя из Articy
@@ -155,6 +159,8 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
         flowPlayer.StartOn = startFragment;
         IsDialogueOpen = true;
 
+        DialogueStarted?.Invoke(this);
+
     }
 
     //public void UpdateDialogue(bool skipPostClose = false) {
@@ -202,6 +208,8 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
                 LoopResetInputScript.TryLoopReset();
             }
         }
+
+        DialogueClosed?.Invoke(this);
     }
 
     public void OnLoopReset() {

--- a/Assets/Scripts/GlobalVariables.cs
+++ b/Assets/Scripts/GlobalVariables.cs
@@ -3,7 +3,6 @@ using UnityEngine;
 using TMPro;
 using Articy.Unity;
 using Articy.World_Of_Red_Moon.GlobalVariables;
-using System.Collections;
 using System.Reflection;
 
 public class GlobalVariables : MonoBehaviour {
@@ -41,16 +40,6 @@ public class GlobalVariables : MonoBehaviour {
         player = new PlayerState(null, false, false);
         player.moralCap = 10;
         player.moralVal = 10;
-        Debug.Log("op");
-        var selector = FindFirstObjectByType<SkillSelectionUI>(FindObjectsInactive.Include);
-        if (selector) {
-            Debug.Log("selector");
-            selector.Open();
-        }
-        StartCoroutine(DelayOpen());
-        IEnumerator DelayOpen() { yield return null; selector?.Open(); }
-
-
         if (!setOfKnowledge) setOfKnowledge = GetComponent<TMP_Text>();
 
         // Subscribe to inventory events to update flags on any change

--- a/Assets/Scripts/SkillSelectionUI.cs
+++ b/Assets/Scripts/SkillSelectionUI.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using UnityEngine;
@@ -8,6 +8,8 @@ using System.Linq;
 using Articy.World_Of_Red_Moon.GlobalVariables;
 
 public class SkillSelectionUI : MonoBehaviour {
+    public event Action Confirmed;
+
     [Header("UI refs")]
     [SerializeField] private TMP_Text pointsLeftText;
     [SerializeField] private Button okButton;
@@ -36,6 +38,7 @@ public class SkillSelectionUI : MonoBehaviour {
     private bool _setupDone;
     private bool _okWired;
     private CanvasGroup _cg;
+    private bool _isOpen;
 
     private void Awake() {
         EnsureSetup();
@@ -144,6 +147,7 @@ public class SkillSelectionUI : MonoBehaviour {
 
         UpdateUI();
         ShowImmediate();                    // ← только CanvasGroup
+        _isOpen = true;
         transform.SetAsLastSibling();       // поверх соседей
         Canvas.ForceUpdateCanvases();
 
@@ -156,6 +160,7 @@ public class SkillSelectionUI : MonoBehaviour {
 
     private void HideImmediate() {
         _cg.alpha = 0f; _cg.interactable = false; _cg.blocksRaycasts = false;
+        _isOpen = false;
     }
 
     private void ActivateParentsChain() {
@@ -240,6 +245,7 @@ public class SkillSelectionUI : MonoBehaviour {
                 s.property.SetValue(ps, s.value);
         }
         HideImmediate(); // только прячем, не выключаем GO
+        Confirmed?.Invoke();
         Debug.Log("[SkillSelectionUI] Confirm → apply & hide (CG)");
     }
 

--- a/Assets/Scripts/StartSequence.cs
+++ b/Assets/Scripts/StartSequence.cs
@@ -1,0 +1,159 @@
+using UnityEngine;
+using Articy.Unity;
+
+/// <summary>
+/// Controls the opening sequence: dialogue A → skill selection → dialogue B.
+/// Ensures the background panel stays visible for the entire sequence.
+/// </summary>
+public class StartSequence : MonoBehaviour
+{
+    [Header("References")]
+    [SerializeField] private DialogueUI dialogueUI;
+    [SerializeField] private SkillSelectionUI skillSelectionUI;
+
+    [Header("Dialogue Starts")]
+    [SerializeField] private ArticyRef dialogueStartA;
+    [SerializeField] private ArticyRef dialogueStartB;
+
+    [Header("UI")]
+    [SerializeField] private GameObject backgroundPanel;
+
+    private enum SequenceStep
+    {
+        None,
+        DialogueA,
+        SkillSelection,
+        DialogueB,
+        Completed
+    }
+
+    private SequenceStep currentStep = SequenceStep.None;
+
+    private void Awake()
+    {
+        if (backgroundPanel != null)
+            backgroundPanel.SetActive(false);
+    }
+
+    private void OnEnable()
+    {
+        if (dialogueUI != null)
+            dialogueUI.DialogueClosed += HandleDialogueClosed;
+        if (skillSelectionUI != null)
+            skillSelectionUI.Confirmed += HandleSkillsConfirmed;
+    }
+
+    private void OnDisable()
+    {
+        if (dialogueUI != null)
+            dialogueUI.DialogueClosed -= HandleDialogueClosed;
+        if (skillSelectionUI != null)
+            skillSelectionUI.Confirmed -= HandleSkillsConfirmed;
+    }
+
+    private void Start()
+    {
+        BeginSequence();
+    }
+
+    private void BeginSequence()
+    {
+        if (currentStep != SequenceStep.None)
+            return;
+
+        if (backgroundPanel != null)
+            backgroundPanel.SetActive(true);
+
+        if (dialogueUI == null)
+        {
+            Debug.LogError("[StartSequence] DialogueUI reference is missing.");
+            FinishSequence();
+            return;
+        }
+
+        if (dialogueStartA == null)
+        {
+            Debug.LogError("[StartSequence] Dialogue start A is not assigned.");
+            FinishSequence();
+            return;
+        }
+
+        currentStep = SequenceStep.DialogueA;
+        dialogueUI.StartDialogue(dialogueStartA);
+    }
+
+    private void HandleDialogueClosed(DialogueUI ui)
+    {
+        if (ui != dialogueUI)
+            return;
+
+        switch (currentStep)
+        {
+            case SequenceStep.DialogueA:
+                StartSkillSelection();
+                break;
+            case SequenceStep.DialogueB:
+                FinishSequence();
+                break;
+        }
+    }
+
+    private void StartSkillSelection()
+    {
+        currentStep = SequenceStep.SkillSelection;
+
+        if (skillSelectionUI == null)
+        {
+            Debug.LogError("[StartSequence] SkillSelectionUI reference is missing.");
+            StartDialogueB();
+            return;
+        }
+
+        skillSelectionUI.Open();
+    }
+
+    private void HandleSkillsConfirmed()
+    {
+        if (currentStep != SequenceStep.SkillSelection)
+            return;
+
+        StartDialogueB();
+    }
+
+    private void StartDialogueB()
+    {
+        currentStep = SequenceStep.DialogueB;
+
+        if (dialogueUI == null)
+        {
+            Debug.LogError("[StartSequence] DialogueUI reference is missing when starting dialogue B.");
+            FinishSequence();
+            return;
+        }
+
+        if (dialogueStartB == null)
+        {
+            Debug.LogError("[StartSequence] Dialogue start B is not assigned.");
+            FinishSequence();
+            return;
+        }
+
+        dialogueUI.StartDialogue(dialogueStartB);
+    }
+
+    private void FinishSequence()
+    {
+        if (currentStep == SequenceStep.Completed)
+            return;
+
+        currentStep = SequenceStep.Completed;
+
+        if (backgroundPanel != null)
+            backgroundPanel.SetActive(false);
+
+        if (dialogueUI != null)
+            dialogueUI.DialogueClosed -= HandleDialogueClosed;
+        if (skillSelectionUI != null)
+            skillSelectionUI.Confirmed -= HandleSkillsConfirmed;
+    }
+}


### PR DESCRIPTION
## Summary
- add a StartSequence controller that runs the introductory dialogue-skill-dialogue flow and manages the background panel
- expose dialogue and skill selection completion events so the sequence can react when each stage ends
- stop auto-opening the skill selection from GlobalVariables so it is only triggered by the new sequence

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d4e80836348330bda73d98c1c45862