### PR TITLE
fix: resolve player light follow target

### DIFF
--- a/Assets/Scripts/PlayerLightController.cs
+++ b/Assets/Scripts/PlayerLightController.cs
@@ -1,0 +1,169 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class PlayerLightController : MonoBehaviour {
+    [Header("Light Settings")]
+    [SerializeField] private GameObject lightObject;
+    [SerializeField] private float fadeDuration = 3f;
+    [SerializeField] private Vector3 lightOffset = Vector3.zero;
+
+    [Header("Follow Target")]
+    [SerializeField] private Transform followTarget;
+
+    private InputAction lightAction;
+    private Light[] lightComponents;
+    private float[] initialIntensities;
+    private float activeTimer;
+    private Transform resolvedFollowTarget;
+    private Transform lightTransform;
+
+    void Awake() {
+        ResolveFollowTarget();
+        CacheLightComponents();
+    }
+
+    void Start() {
+        lightAction = InputSystem.actions?.FindAction("Light");
+        UpdateLightTransform();
+        SetLightActive(false);
+    }
+
+    void OnDestroy() {
+        SetLightActive(false);
+    }
+
+    void Update() {
+        if (lightAction != null && lightAction.triggered) {
+            ActivateLight();
+        }
+
+        if (activeTimer > 0f && lightObject != null) {
+            UpdateLightTransform();
+
+            activeTimer -= Time.deltaTime;
+            float normalized = Mathf.Clamp01(activeTimer / Mathf.Max(fadeDuration, Mathf.Epsilon));
+            ApplyIntensity(normalized);
+
+            if (activeTimer <= 0f) {
+                SetLightActive(false);
+            }
+        }
+    }
+
+    private void ActivateLight() {
+        if (lightObject == null) {
+            return;
+        }
+
+        if (!lightObject.activeSelf) {
+            lightObject.SetActive(true);
+        }
+
+        UpdateLightTransform();
+        activeTimer = Mathf.Max(fadeDuration, Mathf.Epsilon);
+        ApplyIntensity(1f);
+    }
+
+    private void CacheLightComponents() {
+        if (lightObject == null) {
+            lightComponents = System.Array.Empty<Light>();
+            initialIntensities = System.Array.Empty<float>();
+            lightTransform = null;
+            return;
+        }
+
+        lightTransform = lightObject.transform;
+        lightComponents = lightObject.GetComponentsInChildren<Light>(true);
+        initialIntensities = new float[lightComponents.Length];
+        for (int i = 0; i < lightComponents.Length; i++) {
+            initialIntensities[i] = lightComponents[i].intensity;
+        }
+    }
+
+    private void ResolveFollowTarget() {
+        if (followTarget != null) {
+            resolvedFollowTarget = followTarget;
+            return;
+        }
+
+        var movement = GetComponentInParent<PlayerMovementScript>();
+        if (movement != null) {
+            resolvedFollowTarget = movement.transform;
+            return;
+        }
+
+        var resetter = GetComponentInParent<TransformLoopResetter>();
+        if (resetter != null) {
+            resolvedFollowTarget = resetter.transform;
+            return;
+        }
+
+        var fallbackMovement = FindObjectOfType<PlayerMovementScript>();
+        if (fallbackMovement != null) {
+            resolvedFollowTarget = fallbackMovement.transform;
+            return;
+        }
+
+        resolvedFollowTarget = transform;
+    }
+
+    private void UpdateLightTransform() {
+        if (lightTransform == null) {
+            return;
+        }
+
+        if (resolvedFollowTarget == null) {
+            if (Application.isPlaying) {
+                ResolveFollowTarget();
+            } else {
+                resolvedFollowTarget = followTarget != null ? followTarget : transform;
+            }
+        }
+
+        Transform target = resolvedFollowTarget != null ? resolvedFollowTarget : transform;
+        Vector3 worldPosition = target.position + lightOffset;
+        lightTransform.position = worldPosition;
+    }
+
+#if UNITY_EDITOR
+    void OnValidate() {
+        CacheLightComponents();
+        resolvedFollowTarget = followTarget;
+        UpdateLightTransform();
+    }
+#endif
+
+    private void ApplyIntensity(float normalizedValue) {
+        if (lightComponents == null || lightComponents.Length == 0) {
+            return;
+        }
+
+        float clamped = Mathf.Clamp01(normalizedValue);
+        for (int i = 0; i < lightComponents.Length; i++) {
+            lightComponents[i].intensity = initialIntensities[i] * clamped;
+        }
+    }
+
+    private void SetLightActive(bool isActive) {
+        if (lightObject == null) {
+            return;
+        }
+
+        if (isActive) {
+            if (!lightObject.activeSelf) {
+                lightObject.SetActive(true);
+            }
+            activeTimer = Mathf.Max(fadeDuration, Mathf.Epsilon);
+            ApplyIntensity(1f);
+        } else {
+            if (lightComponents != null) {
+                for (int i = 0; i < lightComponents.Length; i++) {
+                    lightComponents[i].intensity = 0f;
+                }
+            }
+
+            lightObject.SetActive(false);
+            activeTimer = 0f;
+        }
+    }
+}

--- a/Assets/Scripts/PlayerLightController.cs.meta
+++ b/Assets/Scripts/PlayerLightController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d05644c70f24c59ba6ff25494acbdf6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- allow specifying an explicit follow target for the player light controller and auto-resolve the player transform when missing
- keep the light transform synced to the resolved target while active and during editor updates
- cache the light transform for reuse while maintaining the existing fade behaviour

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d53ebca6908330ba6ee09e9168a57b