### PR TITLE
Fix flashlight follow and reset rigidbody state

### DIFF
--- a/Assets/Scripts/TransformLoopResetter.cs
+++ b/Assets/Scripts/TransformLoopResetter.cs
@@ -1,31 +1,77 @@
 using UnityEngine;
 
-public class TransformLoopResetter : MonoBehaviour, ILoopResettable
-{
+public class TransformLoopResetter : MonoBehaviour, ILoopResettable {
+    [SerializeField] private bool resetVelocities = true;
+
     private Vector3 _initialPosition;
     private Quaternion _initialRotation;
     private Vector3 _initialScale;
     private Transform _initialParent;
+    private Rigidbody _rigidbody;
 
     public bool resetActiveState;
 
-    void Start()
-    {
-        _initialPosition = transform.position;
-        _initialRotation = transform.rotation;
+    private bool hasCachedState;
+
+    void Awake() {
+        _rigidbody = GetComponent<Rigidbody>();
+        CacheInitialState();
+    }
+
+    void Start() {
+        if (!hasCachedState) {
+            CacheInitialState();
+        }
+    }
+
+    public void OnLoopReset() {
+        if (!hasCachedState) {
+            CacheInitialState();
+        }
+
+        transform.SetParent(_initialParent);
+
+        if (_rigidbody != null) {
+            if (resetVelocities) {
+                TryResetVelocities(_rigidbody);
+            }
+
+            _rigidbody.position = _initialPosition;
+            _rigidbody.rotation = _initialRotation;
+            _rigidbody.MovePosition(_initialPosition);
+            _rigidbody.MoveRotation(_initialRotation);
+        } else {
+            transform.SetPositionAndRotation(_initialPosition, _initialRotation);
+        }
+
+        transform.localScale = _initialScale;
+
+        if (resetActiveState) {
+            gameObject.SetActive(true);
+        }
+    }
+
+    private void CacheInitialState() {
+        hasCachedState = true;
+
+        if (_rigidbody != null) {
+            _initialPosition = _rigidbody.position;
+            _initialRotation = _rigidbody.rotation;
+        } else {
+            _initialPosition = transform.position;
+            _initialRotation = transform.rotation;
+        }
+
         _initialScale = transform.localScale;
         _initialParent = transform.parent;
     }
 
-    public void OnLoopReset()
-    {
-        transform.SetParent(_initialParent);
-        transform.SetPositionAndRotation(_initialPosition, _initialRotation);
-        transform.localScale = _initialScale;
-
-        if (resetActiveState)
-        {
-            gameObject.SetActive(true);
-        }
+    private static void TryResetVelocities(Rigidbody rb) {
+#if UNITY_6000_0_OR_NEWER
+        rb.linearVelocity = Vector3.zero;
+#else
+        rb.velocity = Vector3.zero;
+#endif
+        rb.angularVelocity = Vector3.zero;
     }
 }


### PR DESCRIPTION
## Summary
- ensure the player flashlight action is enabled and keep its transform synchronized with the player every frame
- cache the initial transform state and optionally reset rigidbody velocities before restoring position during loop resets

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d544fc363483308c3cdce3e71db070