### PR TITLE
Fix flashlight spawn position

### DIFF
--- a/Assets/Scripts/PlayerLightController.cs
+++ b/Assets/Scripts/PlayerLightController.cs
@@ -8,6 +8,8 @@ public class PlayerLightController : MonoBehaviour {
     [SerializeField] private Vector3 lightOffset = Vector3.zero;
 
     private InputAction lightAction;
+    [SerializeField] private Transform playerTransform;
+
     private Transform lightTransform;
     private Light[] lightComponents;
     private float[] initialIntensities;
@@ -16,6 +18,18 @@ public class PlayerLightController : MonoBehaviour {
 
     void Awake() {
         cachedTransform = transform;
+
+        if (playerTransform == null) {
+            var movement = FindObjectOfType<PlayerMovementScript>();
+            if (movement != null) {
+                playerTransform = movement.transform;
+            }
+        }
+
+        if (playerTransform == null) {
+            playerTransform = cachedTransform;
+        }
+
         if (lightObject != null) {
             lightTransform = lightObject.transform;
         }
@@ -133,7 +147,7 @@ public class PlayerLightController : MonoBehaviour {
             return;
         }
 
-        Vector3 targetPosition = cachedTransform != null ? cachedTransform.position : transform.position;
+        Vector3 targetPosition = playerTransform != null ? playerTransform.position : cachedTransform.position;
         lightTransform.position = targetPosition + lightOffset;
     }
 }


### PR DESCRIPTION
## Summary
- allow the player light controller to reference an explicit player transform
- fall back to auto-locating the PlayerMovementScript transform to keep the flashlight aligned with the player

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d5464c24488330bd4188a96d75af50