### PR TITLE
feat: allow generic dialogue interactables

### DIFF
--- a/Assets/Scripts/Interactions/DialogueInteractable.cs
+++ b/Assets/Scripts/Interactions/DialogueInteractable.cs
@@ -2,10 +2,12 @@ using UnityEngine;
 using Articy.Unity;
 
 /// <summary>
-/// Base interactable that starts a dialogue when interacted with.
+/// Universal interactable that starts a dialogue when interacted with.
+/// Can be attached to any object with a collider.
 /// Handles the connection to <see cref="DialogueUI"/>.
 /// </summary>
-public abstract class DialogueInteractable : MonoBehaviour, IInteractable
+[RequireComponent(typeof(Collider))]
+public class DialogueInteractable : MonoBehaviour, IInteractable
 {
     [Header("Dialogue")]
     [Tooltip("Articy start node for the dialogue")]


### PR DESCRIPTION
## Summary
- allow `DialogueInteractable` to be attached directly to any collider-equipped object
- add a collider requirement so generic objects can start conversations through the dialogue UI

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d64bdf906c8330ac85c8dde1c46d02