### PR TITLE
Add watched dialogue follow-up sequence

### DIFF
--- a/Assets/Scripts/DialogueSystem/DialogueUI.cs
+++ b/Assets/Scripts/DialogueSystem/DialogueUI.cs
@@ -31,6 +31,7 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
     private string lastDisplayedText = null;
     private string lastSpeakerName = null;
     public bool IsDialogueOpen { get; private set; }
+    public IFlowObject CurrentStartObject { get; private set; }
 
     public IObjectWithFeatureDuration kek;
     private bool suppressOnFlowPause = false;
@@ -126,6 +127,11 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
             return;
         }
         var obj = startRef.GetObject() as IFlowObject;
+        if (obj == null) {
+            Debug.LogError("[DialogueUI] startRef не указывает на IFlowObject — не могу запустить диалог.");
+            return;
+        }
+
         StartDialogue(obj);
     }
 
@@ -134,6 +140,8 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
             Debug.LogWarning("[DialogueUI] StartDialogue(IFlowObject) — пустой startObject или flowPlayer.");
             return;
         }
+
+        CurrentStartObject = startObject;
 
         // сброс состояния UI
         responseHandler?.ClearResponses();
@@ -210,6 +218,8 @@ public class DialogueUI : MonoBehaviour, IArticyFlowPlayerCallbacks, ILoopResett
         }
 
         DialogueClosed?.Invoke(this);
+
+        CurrentStartObject = null;
     }
 
     public void OnLoopReset() {

--- a/Assets/Scripts/DialogueSystem/WatchedDialogueSequence.cs
+++ b/Assets/Scripts/DialogueSystem/WatchedDialogueSequence.cs
@@ -1,0 +1,130 @@
+using UnityEngine;
+using Articy.Unity;
+using Articy.Unity.Interfaces;
+
+public class WatchedDialogueSequence : MonoBehaviour
+{
+    [Header("Dialogue References")]
+    [SerializeField] private DialogueUI dialogueUI;
+    [SerializeField] private ArticyRef watchDialogue;
+    [SerializeField] private ArticyRef guardDialogue;
+
+    [Header("World References")]
+    [SerializeField] private DoorInteractable doorToOpen;
+    [SerializeField] private Transform characterToMove;
+    [SerializeField] private Transform targetTransform;
+
+    private IFlowObject watchedFlowObject;
+    private bool watchedDialogueActive;
+    private bool suppressNextStartCheck;
+
+    private void Reset()
+    {
+        dialogueUI = FindObjectOfType<DialogueUI>();
+    }
+
+    private void Awake()
+    {
+        CacheWatchedFlowObject();
+    }
+
+    private void OnValidate()
+    {
+        CacheWatchedFlowObject();
+    }
+
+    private void OnEnable()
+    {
+        CacheWatchedFlowObject();
+        Subscribe();
+    }
+
+    private void OnDisable()
+    {
+        Unsubscribe();
+    }
+
+    private void Subscribe()
+    {
+        if (dialogueUI == null)
+            dialogueUI = FindObjectOfType<DialogueUI>();
+
+        if (dialogueUI == null)
+        {
+            Debug.LogWarning($"[{nameof(WatchedDialogueSequence)}] DialogueUI not assigned.");
+            return;
+        }
+
+        dialogueUI.DialogueStarted += OnDialogueStarted;
+        dialogueUI.DialogueClosed += OnDialogueClosed;
+    }
+
+    private void Unsubscribe()
+    {
+        if (dialogueUI == null)
+            return;
+
+        dialogueUI.DialogueStarted -= OnDialogueStarted;
+        dialogueUI.DialogueClosed -= OnDialogueClosed;
+    }
+
+    private void CacheWatchedFlowObject()
+    {
+        if (watchDialogue == null)
+        {
+            watchedFlowObject = null;
+            return;
+        }
+
+        var articyObject = watchDialogue.GetObject();
+        var flowObject = articyObject as IFlowObject;
+        if (articyObject != null && flowObject == null)
+        {
+            Debug.LogWarning($"[{nameof(WatchedDialogueSequence)}] watchDialogue does not reference an IFlowObject.");
+        }
+
+        watchedFlowObject = flowObject;
+    }
+
+    private void OnDialogueStarted(DialogueUI ui)
+    {
+        if (ui != dialogueUI)
+            return;
+
+        if (suppressNextStartCheck)
+        {
+            suppressNextStartCheck = false;
+            watchedDialogueActive = false;
+            return;
+        }
+
+        if (watchedFlowObject == null && watchDialogue != null)
+            CacheWatchedFlowObject();
+
+        var currentStart = ui.CurrentStartObject;
+        watchedDialogueActive = currentStart != null && watchedFlowObject != null && currentStart == watchedFlowObject;
+    }
+
+    private void OnDialogueClosed(DialogueUI ui)
+    {
+        if (ui != dialogueUI)
+            return;
+
+        if (!watchedDialogueActive)
+            return;
+
+        watchedDialogueActive = false;
+
+        if (doorToOpen != null)
+            doorToOpen.ForceOpen();
+
+        if (characterToMove != null && targetTransform != null)
+            characterToMove.SetPositionAndRotation(targetTransform.position, targetTransform.rotation);
+
+        if (dialogueUI != null && guardDialogue != null)
+        {
+            suppressNextStartCheck = true;
+            dialogueUI.StartDialogue(guardDialogue);
+        }
+    }
+}

--- a/Assets/Scripts/DialogueSystem/WatchedDialogueSequence.cs.meta
+++ b/Assets/Scripts/DialogueSystem/WatchedDialogueSequence.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e5bb5996cb4439ca798590840fe819f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactions/DoorInteractable.cs
+++ b/Assets/Scripts/Interactions/DoorInteractable.cs
@@ -30,6 +30,11 @@ public class DoorInteractable : MonoBehaviour, IInteractable, ILoopResettable
         ApplyState(startIsOpen);
     }
 
+    public void ForceOpen()
+    {
+        ApplyState(true);
+    }
+
     private void ApplyState(bool open)
     {
         isOpen = open;


### PR DESCRIPTION
## Summary
- expose the active flow object on DialogueUI so listeners can react to specific conversations
- add a door helper for forcing doors open and introduce WatchedDialogueSequence to open a door, reposition the player, and start a guard dialogue after the watched conversation closes

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d6ade339e48330914ebb0daa542cf3