### PR TITLE
feat: toggle player skills visibility

### DIFF
--- a/Assets/Scripts/PlayerStatsDisplay.cs
+++ b/Assets/Scripts/PlayerStatsDisplay.cs
@@ -3,30 +3,73 @@ using System.Reflection;
 using System.Text;
 using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
 using Articy.World_Of_Red_Moon.GlobalVariables;
 
 public class PlayerStatsDisplay : MonoBehaviour {
     [SerializeField] private TMP_Text targetText;
+    [SerializeField] private Button showSkillsButton;
+    [SerializeField] private TMP_Text showSkillsButtonLabel;
+
+    private bool skillsVisible;
 
     private void Awake() {
         if (targetText == null)
             targetText = GetComponent<TMP_Text>();
+
+        CacheShowSkillsButton();
+        UpdateShowSkillsButtonLabel();
     }
 
     private void Update() {
+        UpdateDisplay();
+    }
+
+    private void OnDestroy() {
+        if (showSkillsButton != null)
+            showSkillsButton.onClick.RemoveListener(ToggleSkillsVisibility);
+    }
+
+    private void UpdateDisplay() {
         if (targetText == null || GlobalVariables.Instance == null)
             return;
 
         var player = GlobalVariables.Instance.player;
         int loopState = ArticyGlobalVariables.Default.PS.loopCounter;
 
-        string skillsBlock = BuildSkillsBlock();
+        string skillsSection = skillsVisible
+            ? "Skills:\n" + BuildSkillsBlock()
+            : "Skills: —";
 
         targetText.text =
             $"Moral: {player.moralVal}/{player.moralCap}\n" +
             $"Loop: {loopState}\n" +
-            "Skills:\n" +
-            skillsBlock;
+            skillsSection;
+    }
+
+    private void CacheShowSkillsButton() {
+        if (showSkillsButton == null)
+            showSkillsButton = GetComponentsInChildren<Button>(true)
+                .FirstOrDefault(b => b.gameObject.name == "ShowSkills");
+
+        if (showSkillsButton != null) {
+            showSkillsButton.onClick.RemoveListener(ToggleSkillsVisibility);
+            showSkillsButton.onClick.AddListener(ToggleSkillsVisibility);
+
+            if (showSkillsButtonLabel == null)
+                showSkillsButtonLabel = showSkillsButton.GetComponentInChildren<TMP_Text>();
+        }
+    }
+
+    private void ToggleSkillsVisibility() {
+        skillsVisible = !skillsVisible;
+        UpdateShowSkillsButtonLabel();
+        UpdateDisplay();
+    }
+
+    private void UpdateShowSkillsButtonLabel() {
+        if (showSkillsButtonLabel != null)
+            showSkillsButtonLabel.text = skillsVisible ? "-" : "+";
     }
 
     private static string BuildSkillsBlock() {


### PR DESCRIPTION
## Summary
- hide the player skills list by default in the stats display
- wire the ShowSkills button to toggle the list visibility and update its label
- ensure the stats text refreshes immediately when toggled

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d7c1e8695083309168c875f52e87c8