### PR TITLE
Add test toggle to JournalUI description display

### DIFF
--- a/Assets/Scripts/Journal/JournalUI.cs
+++ b/Assets/Scripts/Journal/JournalUI.cs
@@ -11,6 +11,7 @@ public class JournalUI : MonoBehaviour
     [SerializeField] private Transform questItemsParent;
     [SerializeField] private GameObject questItemPrefab;
     [SerializeField] private TMP_Text descriptionText;
+    [SerializeField] private bool test = true;
 
     private readonly List<GameObject> spawnedQuestItems = new();
     private QuestManager.Quest selectedQuest;
@@ -69,7 +70,15 @@ public class JournalUI : MonoBehaviour
         if (descriptionText == null)
             return;
 
-        descriptionText.text = quest == null ? string.Empty : QuestManager.DescribeQuest(quest);
+        if (quest == null)
+        {
+            descriptionText.text = string.Empty;
+            return;
+        }
+
+        descriptionText.text = test
+            ? QuestManager.DescribeQuest(quest)
+            : quest.CurrentDescription ?? string.Empty;
     }
 
     private void HandleQuestChanged(QuestManager.Quest _)


### PR DESCRIPTION
## Summary
- add a serialized test flag to JournalUI for controlling quest description detail
- limit the journal description text to the quest's current description when the flag is disabled

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d7d7d2873c8330b006a929d7e5df79