### PR TITLE
Hide not started quests when Journal test mode is disabled

### DIFF
--- a/Assets/Scripts/Journal/JournalUI.cs
+++ b/Assets/Scripts/Journal/JournalUI.cs
@@ -105,6 +105,7 @@ public class JournalUI : MonoBehaviour
 
         var quests = QuestManager
             .GetAllQuests()
+            .Where(q => test || q.State != QuestState.NotStarted)
             .OrderBy(q => q.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
 


### PR DESCRIPTION
## Summary
- update the Journal UI refresh logic to skip quests that are still NotStarted when the test flag is disabled

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d7db4f1a7c83308859856af4cb41f0