### PR TITLE
Fix Journal UI escape handling

### DIFF
--- a/Assets/Scripts/Journal/JournalInputScript.cs
+++ b/Assets/Scripts/Journal/JournalInputScript.cs
@@ -4,11 +4,13 @@ using UnityEngine.InputSystem;
 public class JournalInputScript : MonoBehaviour
 {
     private InputAction journalAction;
+    private InputAction escapeAction;
     private JournalUI journalUI;
 
     private void Start()
     {
         journalAction = InputSystem.actions?.FindAction("Journal");
+        escapeAction = InputSystem.actions?.FindAction("Escape");
         journalUI = FindObjectOfType<JournalUI>();
     }
 
@@ -18,16 +20,21 @@ public class JournalInputScript : MonoBehaviour
             return;
 
         if (journalAction == null)
-        {
             journalAction = InputSystem.actions?.FindAction("Journal");
-            if (journalAction == null)
-                return;
+
+        if (escapeAction == null)
+            escapeAction = InputSystem.actions?.FindAction("Escape");
+
+        if (journalAction != null && journalAction.triggered)
+        {
+            journalUI.Show();
+            Debug.Log("journal opened");
         }
 
-        if (journalAction.triggered) {
-            journalUI.Toggle();
-            Debug.Log("journal called");
+        if (escapeAction != null && escapeAction.triggered)
+        {
+            journalUI.Hide();
+            Debug.Log("journal closed");
         }
-            
     }
 }


### PR DESCRIPTION
## Summary
- ensure the Journal UI listens to the Escape input action to close, matching the Inventory behaviour
- open the Journal UI explicitly when the Journal action is triggered instead of toggling

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d7dc84a77483308a2accc220c0f776