### PR TITLE
Ensure GameOver triggers when moral depletes

### DIFF
--- a/Assets/Scripts/GlobalVariables.cs
+++ b/Assets/Scripts/GlobalVariables.cs
@@ -132,8 +132,13 @@ public class GlobalVariables : MonoBehaviour {
         int currentVal = ps.moralVal;
         int currentCap = ps.moralCap;
 
-        if (!forceCheck && currentVal == lastArticyMoralVal && currentCap == lastArticyMoralCap)
+        bool reachedZero = currentVal <= 0 || currentCap <= 0;
+
+        if (!forceCheck && currentVal == lastArticyMoralVal && currentCap == lastArticyMoralCap) {
+            if (reachedZero)
+                GameOver.Trigger();
             return;
+        }
 
         int clampedCap = Mathf.Max(0, currentCap);
         if (clampedCap != currentCap)


### PR DESCRIPTION
## Summary
- ensure the GameOver sequence runs even if the moral values have not changed between frames but are already zero or below
- keep the original clamping logic so future changes still trigger the panel

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d8e7b3a3688330bf72e9566f49f47b