### PR TITLE
Fix EndOfTheDemo trigger when playing the assigned fragment

### DIFF
--- a/Assets/Scripts/EndOfTheDemo.cs
+++ b/Assets/Scripts/EndOfTheDemo.cs
@@ -73,18 +73,37 @@ public class EndOfTheDemo : MonoBehaviour {
             CacheTargetFlowObject();
 
         var currentStart = ui.CurrentStartObject;
-        isWatching = currentStart != null && targetFlowObject != null && currentStart == targetFlowObject;
+        isWatching = FlowObjectsMatch(currentStart, targetFlowObject);
     }
 
     private void OnDialogueClosed(DialogueUI ui) {
         if (hasTriggered || ui != dialogueUI)
             return;
 
-        if (!isWatching)
+        var currentStart = ui.CurrentStartObject;
+        var wasTargetDialogue = isWatching || FlowObjectsMatch(currentStart, targetFlowObject);
+        isWatching = false;
+
+        if (!wasTargetDialogue)
             return;
 
-        isWatching = false;
         TriggerEndOfDemo();
+    }
+
+    private static bool FlowObjectsMatch(IFlowObject currentStart, IFlowObject target) {
+        if (ReferenceEquals(currentStart, target))
+            return true;
+
+        if (currentStart == null || target == null)
+            return false;
+
+        if (currentStart.Equals(target))
+            return true;
+
+        if (currentStart is ArticyObject currentArticy && target is ArticyObject targetArticy)
+            return Equals(currentArticy.Id, targetArticy.Id);
+
+        return false;
     }
 
     private void TriggerEndOfDemo() {


### PR DESCRIPTION
## Summary
- compare the watched dialogue fragment using Articy identity instead of reference equality in EndOfTheDemo
- re-evaluate the current dialogue on close so the end sequence fires even if the start hook missed it

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d8eedb790c8330b29bac5cf9c90b6d