### PR TITLE
Fix dialogue target comparison

### DIFF
--- a/Assets/Scripts/EndOfTheDemo.cs
+++ b/Assets/Scripts/EndOfTheDemo.cs
@@ -75,7 +75,7 @@ public class EndOfTheDemo : MonoBehaviour {
 
         var currentStart = ui.CurrentStartObject;
         Debug.Log("start to watch");
-        var matchesTarget = currentStart != null && targetFlowObject != null && ReferenceEquals(currentStart, targetFlowObject);
+        var matchesTarget = currentStart != null && targetFlowObject != null && currentStart == targetFlowObject;
 
         watchedDialogueActive = matchesTarget;
     }


### PR DESCRIPTION
## Summary
- update the dialogue start check so the current start object is compared directly against the cached target flow object

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8faf421f8833087a27a0ee69b59f7