### PR TITLE
Add knowledge journal UI

### DIFF
--- a/Assets/Scripts/Knowledge.meta
+++ b/Assets/Scripts/Knowledge.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3ac2a0da18584e61b37f1d650d885e04
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Knowledge/KnowledgeInputScript.cs
+++ b/Assets/Scripts/Knowledge/KnowledgeInputScript.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class KnowledgeInputScript : MonoBehaviour
+{
+    private InputAction knowledgeAction;
+    private InputAction escapeAction;
+    private KnowledgeUI knowledgeUI;
+
+    private void Start()
+    {
+        knowledgeAction = InputSystem.actions?.FindAction("Knowledge");
+        escapeAction = InputSystem.actions?.FindAction("Escape");
+        knowledgeUI = FindObjectOfType<KnowledgeUI>();
+    }
+
+    private void Update()
+    {
+        if (knowledgeUI == null)
+        {
+            knowledgeUI = FindObjectOfType<KnowledgeUI>();
+            if (knowledgeUI == null)
+                return;
+        }
+
+        if (knowledgeAction == null)
+            knowledgeAction = InputSystem.actions?.FindAction("Knowledge");
+
+        if (escapeAction == null)
+            escapeAction = InputSystem.actions?.FindAction("Escape");
+
+        if (knowledgeAction != null && knowledgeAction.triggered)
+        {
+            knowledgeUI.Show();
+            Debug.Log("knowledge opened");
+        }
+
+        if (escapeAction != null && escapeAction.triggered)
+        {
+            knowledgeUI.Hide();
+            Debug.Log("knowledge closed");
+        }
+    }
+}

--- a/Assets/Scripts/Knowledge/KnowledgeInputScript.cs.meta
+++ b/Assets/Scripts/Knowledge/KnowledgeInputScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83ae8fa7d79e4814a0d2af8e5a49afee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Knowledge/KnowledgeItemUI.cs
+++ b/Assets/Scripts/Knowledge/KnowledgeItemUI.cs
@@ -1,0 +1,37 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class KnowledgeItemUI : MonoBehaviour
+{
+    private KnowledgeManager.Knowledge knowledge;
+    private KnowledgeUI knowledgeUI;
+
+    public void Initialize(KnowledgeManager.Knowledge knowledge, KnowledgeUI ui)
+    {
+        this.knowledge = knowledge;
+        knowledgeUI = ui;
+
+        UpdateLabel();
+
+        var button = GetComponent<Button>();
+        if (button != null)
+        {
+            button.onClick.RemoveListener(OnClick);
+            button.onClick.AddListener(OnClick);
+        }
+    }
+
+    private void UpdateLabel()
+    {
+        var text = GetComponentInChildren<TMP_Text>();
+        if (text != null)
+            text.text = KnowledgeUI.FormatKnowledgeName(knowledge?.Name ?? string.Empty);
+    }
+
+    private void OnClick()
+    {
+        if (knowledge != null)
+            knowledgeUI?.SelectKnowledge(knowledge);
+    }
+}

--- a/Assets/Scripts/Knowledge/KnowledgeItemUI.cs.meta
+++ b/Assets/Scripts/Knowledge/KnowledgeItemUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93de7d161b4448cdbe3f39d5e21103a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Knowledge/KnowledgeUI.cs
+++ b/Assets/Scripts/Knowledge/KnowledgeUI.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using TMPro;
+using UnityEngine;
+
+public class KnowledgeUI : MonoBehaviour
+{
+    [Header("UI References")]
+    [SerializeField] private GameObject knowledgePanel;
+    [SerializeField] private Transform knowledgeItemsParent;
+    [SerializeField] private GameObject knowledgeItemPrefab;
+    [SerializeField] private TMP_Text descriptionText;
+
+    private readonly List<GameObject> spawnedKnowledgeItems = new();
+    private KnowledgeManager.Knowledge selectedKnowledge;
+
+    private void OnEnable()
+    {
+        KnowledgeManager.KnowledgeChanged += HandleKnowledgeChanged;
+    }
+
+    private void OnDisable()
+    {
+        KnowledgeManager.KnowledgeChanged -= HandleKnowledgeChanged;
+    }
+
+    private void Start()
+    {
+        if (knowledgeItemPrefab != null)
+            knowledgeItemPrefab.SetActive(false);
+
+        Hide();
+        Refresh();
+    }
+
+    public void Show()
+    {
+        Refresh();
+        if (knowledgePanel != null)
+            knowledgePanel.SetActive(true);
+    }
+
+    public void Hide()
+    {
+        if (knowledgePanel != null)
+            knowledgePanel.SetActive(false);
+    }
+
+    public void Toggle()
+    {
+        if (knowledgePanel == null)
+            return;
+
+        if (knowledgePanel.activeSelf)
+            Hide();
+        else
+            Show();
+    }
+
+    public void SelectKnowledge(KnowledgeManager.Knowledge knowledge)
+    {
+        selectedKnowledge = knowledge;
+        DisplayKnowledge(knowledge);
+    }
+
+    public void Refresh()
+    {
+        if (knowledgeItemsParent == null || knowledgeItemPrefab == null)
+        {
+            DisplayKnowledge(null);
+            return;
+        }
+
+        string previousSelectionName = selectedKnowledge?.Name;
+
+        foreach (var instance in spawnedKnowledgeItems)
+        {
+            if (instance != null)
+                Destroy(instance);
+        }
+        spawnedKnowledgeItems.Clear();
+
+        var knowledges = KnowledgeManager.GetAllKnowledges().ToList();
+
+        selectedKnowledge = null;
+
+        foreach (var knowledge in knowledges)
+        {
+            var instance = Instantiate(knowledgeItemPrefab, knowledgeItemsParent);
+            instance.SetActive(true);
+
+            var itemUI = instance.GetComponent<KnowledgeItemUI>() ?? instance.AddComponent<KnowledgeItemUI>();
+            itemUI.Initialize(knowledge, this);
+            spawnedKnowledgeItems.Add(instance);
+
+            if (!string.IsNullOrEmpty(previousSelectionName) && string.Equals(knowledge.Name, previousSelectionName, StringComparison.Ordinal))
+                selectedKnowledge = knowledge;
+        }
+
+        if (selectedKnowledge == null && knowledges.Count > 0)
+            selectedKnowledge = knowledges[0];
+
+        DisplayKnowledge(selectedKnowledge);
+    }
+
+    private void HandleKnowledgeChanged()
+    {
+        Refresh();
+    }
+
+    private void DisplayKnowledge(KnowledgeManager.Knowledge knowledge)
+    {
+        if (descriptionText == null)
+            return;
+
+        if (knowledge == null)
+        {
+            descriptionText.text = string.Empty;
+            return;
+        }
+
+        descriptionText.text = FormatKnowledgeName(knowledge.Name);
+    }
+
+    internal static string FormatKnowledgeName(string rawName)
+    {
+        if (string.IsNullOrWhiteSpace(rawName))
+            return string.Empty;
+
+        var builder = new StringBuilder(rawName.Length * 2);
+        bool lastAppendedSpace = false;
+
+        foreach (char character in rawName)
+        {
+            if (character == '_' || character == '-')
+            {
+                if (!lastAppendedSpace && builder.Length > 0)
+                {
+                    builder.Append(' ');
+                    lastAppendedSpace = true;
+                }
+
+                continue;
+            }
+
+            bool shouldInsertSpace = char.IsUpper(character)
+                && builder.Length > 0
+                && !lastAppendedSpace
+                && char.IsLetterOrDigit(builder[builder.Length - 1])
+                && char.IsLower(builder[builder.Length - 1]);
+
+            if (shouldInsertSpace)
+            {
+                builder.Append(' ');
+            }
+
+            builder.Append(character);
+            lastAppendedSpace = false;
+        }
+
+        return builder.ToString().Trim();
+    }
+}

--- a/Assets/Scripts/Knowledge/KnowledgeUI.cs.meta
+++ b/Assets/Scripts/Knowledge/KnowledgeUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9bc3a92d9b8746f5b0bfb5c9e6f00642
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/KnowledgeManager.cs
+++ b/Assets/Scripts/KnowledgeManager.cs
@@ -1,28 +1,57 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
-public static class KnowledgeManager {
-    public class Knowledge {
+public static class KnowledgeManager
+{
+    public class Knowledge
+    {
         public string Name;
     }
 
     private static readonly Dictionary<string, Knowledge> knowledges = new();
 
-    public static void AddKnowledge(string name) {
-        knowledges[name] = new Knowledge { Name = name};
+    public static event Action KnowledgeChanged;
+
+    public static void AddKnowledge(string name)
+    {
+        knowledges[name] = new Knowledge { Name = name };
+        NotifyKnowledgeChanged();
     }
 
-    public static string DisplayKnowledges() {
+    public static string DisplayKnowledges()
+    {
         var sb = new StringBuilder();
-        foreach (var q in knowledges.Values)
-            sb.AppendLine($"{q.Name} | ");
+        foreach (var knowledge in GetAllKnowledges())
+            sb.AppendLine($"{knowledge.Name} | ");
         return sb.ToString();
     }
 
-    public static bool RemoveKnowledge(string name) => knowledges.Remove(name);
+    public static bool RemoveKnowledge(string name)
+    {
+        bool removed = knowledges.Remove(name);
+        if (removed)
+            NotifyKnowledgeChanged();
+        return removed;
+    }
 
-    public static void ResetKnowledges() => knowledges.Clear();
+    public static void ResetKnowledges()
+    {
+        if (knowledges.Count == 0)
+            return;
 
-    // Удобные проверки для диалогов
+        knowledges.Clear();
+        NotifyKnowledgeChanged();
+    }
+
+    //
     public static bool HasKnowledge(string name) => knowledges.ContainsKey(name);
+
+    public static IReadOnlyList<Knowledge> GetAllKnowledges() => knowledges
+        .Values
+        .OrderBy(k => k.Name, StringComparer.OrdinalIgnoreCase)
+        .ToList();
+
+    private static void NotifyKnowledgeChanged() => KnowledgeChanged?.Invoke();
 }


### PR DESCRIPTION
## Summary
- add a Knowledge UI that mirrors the journal layout for displaying collected knowledge entries with formatted descriptions
- hook up a Knowledge input action and escape handler for opening and closing the panel
- extend the knowledge manager with change notifications and sorted retrieval to keep the UI in sync

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d91cf13d248330948f6f56ad9a0f9d