### PR TITLE
Enable knowledge drag-and-drop combinations

### DIFF
--- a/Assets/Scripts/Knowledge/KnowledgeItemUI.cs
+++ b/Assets/Scripts/Knowledge/KnowledgeItemUI.cs
@@ -1,11 +1,21 @@
 using TMPro;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
-public class KnowledgeItemUI : MonoBehaviour
+public class KnowledgeItemUI : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler, IDropHandler
 {
     private KnowledgeManager.Knowledge knowledge;
     private KnowledgeUI knowledgeUI;
+    private CanvasGroup canvasGroup;
+    private static KnowledgeItemUI currentlyDragging;
+
+    private void Awake()
+    {
+        canvasGroup = GetComponent<CanvasGroup>();
+        if (canvasGroup == null)
+            canvasGroup = gameObject.AddComponent<CanvasGroup>();
+    }
 
     public void Initialize(KnowledgeManager.Knowledge knowledge, KnowledgeUI ui)
     {
@@ -14,12 +24,56 @@ public class KnowledgeItemUI : MonoBehaviour
 
         UpdateLabel();
 
+        if (canvasGroup == null)
+            canvasGroup = GetComponent<CanvasGroup>();
+
         var button = GetComponent<Button>();
         if (button != null)
         {
             button.onClick.RemoveListener(OnClick);
             button.onClick.AddListener(OnClick);
         }
+    }
+
+    public void OnBeginDrag(PointerEventData eventData)
+    {
+        if (knowledge == null)
+            return;
+
+        currentlyDragging = this;
+        if (canvasGroup != null)
+        {
+            canvasGroup.alpha = 0.7f;
+            canvasGroup.blocksRaycasts = false;
+        }
+    }
+
+    public void OnDrag(PointerEventData eventData)
+    {
+    }
+
+    public void OnEndDrag(PointerEventData eventData)
+    {
+        if (currentlyDragging == this)
+            currentlyDragging = null;
+
+        if (canvasGroup != null)
+        {
+            canvasGroup.alpha = 1f;
+            canvasGroup.blocksRaycasts = true;
+        }
+    }
+
+    public void OnDrop(PointerEventData eventData)
+    {
+        if (currentlyDragging == null || currentlyDragging == this)
+            return;
+
+        var sourceKnowledgeName = currentlyDragging.knowledge?.Name;
+        var targetKnowledgeName = knowledge?.Name;
+
+        if (KnowledgeManager.TryCombineKnowledge(sourceKnowledgeName, targetKnowledgeName, out var resultKnowledge))
+            knowledgeUI?.RequestSelectKnowledge(resultKnowledge);
     }
 
     private void UpdateLabel()

--- a/Assets/Scripts/Knowledge/KnowledgeUI.cs
+++ b/Assets/Scripts/Knowledge/KnowledgeUI.cs
@@ -15,6 +15,7 @@ public class KnowledgeUI : MonoBehaviour
 
     private readonly List<GameObject> spawnedKnowledgeItems = new();
     private KnowledgeManager.Knowledge selectedKnowledge;
+    private string pendingSelectionName;
 
     private void OnEnable()
     {
@@ -73,7 +74,10 @@ public class KnowledgeUI : MonoBehaviour
             return;
         }
 
-        string previousSelectionName = selectedKnowledge?.Name;
+        string previousSelectionName = !string.IsNullOrEmpty(pendingSelectionName)
+            ? pendingSelectionName
+            : selectedKnowledge?.Name;
+        pendingSelectionName = null;
 
         foreach (var instance in spawnedKnowledgeItems)
         {
@@ -122,6 +126,12 @@ public class KnowledgeUI : MonoBehaviour
         }
 
         descriptionText.text = FormatKnowledgeName(knowledge.Name);
+    }
+
+    internal void RequestSelectKnowledge(string knowledgeName)
+    {
+        if (!string.IsNullOrWhiteSpace(knowledgeName))
+            pendingSelectionName = knowledgeName;
     }
 
     internal static string FormatKnowledgeName(string rawName)

--- a/Assets/Scripts/KnowledgeManager.cs
+++ b/Assets/Scripts/KnowledgeManager.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
+using Articy.Unity;
+using Articy.World_Of_Red_Moon.GlobalVariables;
 
 public static class KnowledgeManager
 {
@@ -11,13 +14,41 @@ public static class KnowledgeManager
     }
 
     private static readonly Dictionary<string, Knowledge> knowledges = new();
+    private static readonly Dictionary<CombinationKey, string> combinationResults = new()
+    {
+        { CombinationKey.Create("testA", "testB"), "testD" },
+        { CombinationKey.Create("testD", "testC"), "testE" }
+    };
 
     public static event Action KnowledgeChanged;
 
     public static void AddKnowledge(string name)
     {
+        if (string.IsNullOrWhiteSpace(name))
+            return;
+
         knowledges[name] = new Knowledge { Name = name };
+        SetArticyKnowledgeState(name, true);
         NotifyKnowledgeChanged();
+    }
+
+    public static bool TryCombineKnowledge(string firstKnowledge, string secondKnowledge, out string resultKnowledge)
+    {
+        resultKnowledge = null;
+
+        if (string.IsNullOrWhiteSpace(firstKnowledge) || string.IsNullOrWhiteSpace(secondKnowledge))
+            return false;
+
+        var key = CombinationKey.Create(firstKnowledge, secondKnowledge);
+        if (!combinationResults.TryGetValue(key, out var targetKnowledge))
+            return false;
+
+        if (!HasKnowledge(firstKnowledge) || !HasKnowledge(secondKnowledge))
+            return false;
+
+        resultKnowledge = targetKnowledge;
+        AddKnowledge(targetKnowledge);
+        return true;
     }
 
     public static string DisplayKnowledges()
@@ -54,4 +85,53 @@ public static class KnowledgeManager
         .ToList();
 
     private static void NotifyKnowledgeChanged() => KnowledgeChanged?.Invoke();
+
+    private static void SetArticyKnowledgeState(string knowledgeName, bool value)
+    {
+        var globals = ArticyGlobalVariables.Default;
+        if (globals == null)
+            return;
+
+        var knowledgeContainer = globals.NKNW;
+        if (knowledgeContainer == null)
+            return;
+
+        var property = typeof(NKNW).GetProperty(knowledgeName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase);
+        if (property == null || property.PropertyType != typeof(bool) || property.GetIndexParameters().Length != 0 || !property.CanWrite)
+            return;
+
+        property.SetValue(knowledgeContainer, value);
+    }
+
+    private readonly struct CombinationKey : IEquatable<CombinationKey>
+    {
+        private readonly string first;
+        private readonly string second;
+
+        private CombinationKey(string first, string second)
+        {
+            this.first = first;
+            this.second = second;
+        }
+
+        public static CombinationKey Create(string firstKnowledge, string secondKnowledge)
+        {
+            string normalizedFirst = Normalize(firstKnowledge);
+            string normalizedSecond = Normalize(secondKnowledge);
+
+            return string.Compare(normalizedFirst, normalizedSecond, StringComparison.Ordinal) <= 0
+                ? new CombinationKey(normalizedFirst, normalizedSecond)
+                : new CombinationKey(normalizedSecond, normalizedFirst);
+        }
+
+        public bool Equals(CombinationKey other) => first == other.first && second == other.second;
+
+        public override bool Equals(object obj) => obj is CombinationKey other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(first, second);
+
+        private static string Normalize(string value) => string.IsNullOrWhiteSpace(value)
+            ? string.Empty
+            : value.Trim().ToUpperInvariant();
+    }
 }


### PR DESCRIPTION
## Summary
- add drag-and-drop handling to knowledge items and track selection of new results
- wire knowledge combinations to Articy global variables with sample rules for test knowledges

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d924f4687883308506bd7550542c86