### PR TITLE
Fix start and guard dialogue sequencing layering

### DIFF
--- a/Assets/Scripts/DialogueSystem/WatchedDialogueSequence.cs
+++ b/Assets/Scripts/DialogueSystem/WatchedDialogueSequence.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 using Articy.Unity;
 using Articy.Unity.Interfaces;
@@ -9,6 +10,10 @@ public class WatchedDialogueSequence : MonoBehaviour
     [SerializeField] private ArticyRef watchDialogue;
     [SerializeField] private ArticyRef guardDialogue;
 
+    [Header("Guard Dialogue")]
+    [SerializeField] private GameObject guardDialogueBackground;
+    [SerializeField] private float guardDialogueDelay = 3f;
+
     [Header("World References")]
     [SerializeField] private DoorInteractable doorToOpen;
     [SerializeField] private Transform characterToMove;
@@ -17,6 +22,11 @@ public class WatchedDialogueSequence : MonoBehaviour
     private IFlowObject watchedFlowObject;
     private bool watchedDialogueActive;
     private bool suppressNextStartCheck;
+    private bool guardDialogueActive;
+    private Coroutine guardDialogueRoutine;
+    private Vector3 originalCharacterPosition;
+    private Quaternion originalCharacterRotation;
+    private bool hasOriginalCharacterTransform;
 
     private void Reset()
     {
@@ -26,21 +36,29 @@ public class WatchedDialogueSequence : MonoBehaviour
     private void Awake()
     {
         CacheWatchedFlowObject();
+        CacheOriginalCharacterTransform();
+        HideGuardDialogueBackground();
     }
 
     private void OnValidate()
     {
         CacheWatchedFlowObject();
+        if (!Application.isPlaying)
+            CacheOriginalCharacterTransform();
     }
 
     private void OnEnable()
     {
         CacheWatchedFlowObject();
+        EnsureOriginalCharacterTransformCached();
+        HideGuardDialogueBackground();
         Subscribe();
     }
 
     private void OnDisable()
     {
+        CancelGuardDialogueRoutine();
+        HideGuardDialogueBackground();
         Unsubscribe();
     }
 
@@ -86,6 +104,53 @@ public class WatchedDialogueSequence : MonoBehaviour
         watchedFlowObject = flowObject;
     }
 
+    private void CacheOriginalCharacterTransform()
+    {
+        if (characterToMove == null)
+        {
+            hasOriginalCharacterTransform = false;
+            return;
+        }
+
+        originalCharacterPosition = characterToMove.position;
+        originalCharacterRotation = characterToMove.rotation;
+        hasOriginalCharacterTransform = true;
+    }
+
+    private void EnsureOriginalCharacterTransformCached()
+    {
+        if (hasOriginalCharacterTransform || characterToMove == null)
+            return;
+
+        CacheOriginalCharacterTransform();
+    }
+
+    private void RestoreCharacterToOriginal()
+    {
+        if (!hasOriginalCharacterTransform || characterToMove == null)
+            return;
+
+        characterToMove.SetPositionAndRotation(originalCharacterPosition, originalCharacterRotation);
+    }
+
+    private void HideGuardDialogueBackground()
+    {
+        if (guardDialogueBackground == null)
+            return;
+
+        guardDialogueBackground.SetActive(false);
+    }
+
+    private void CancelGuardDialogueRoutine()
+    {
+        if (guardDialogueRoutine == null)
+            return;
+
+        StopCoroutine(guardDialogueRoutine);
+        guardDialogueRoutine = null;
+        HideGuardDialogueBackground();
+    }
+
     private void OnDialogueStarted(DialogueUI ui)
     {
         if (ui != dialogueUI)
@@ -110,6 +175,13 @@ public class WatchedDialogueSequence : MonoBehaviour
         if (ui != dialogueUI)
             return;
 
+        if (guardDialogueActive)
+        {
+            guardDialogueActive = false;
+            RestoreCharacterToOriginal();
+            return;
+        }
+
         if (!watchedDialogueActive)
             return;
 
@@ -121,10 +193,31 @@ public class WatchedDialogueSequence : MonoBehaviour
         if (characterToMove != null && targetTransform != null)
             characterToMove.SetPositionAndRotation(targetTransform.position, targetTransform.rotation);
 
+        CancelGuardDialogueRoutine();
+
+        if (dialogueUI != null && guardDialogue != null)
+            guardDialogueRoutine = StartCoroutine(BeginGuardDialogueSequence());
+    }
+
+    private IEnumerator BeginGuardDialogueSequence()
+    {
+        if (guardDialogueBackground != null)
+            guardDialogueBackground.SetActive(true);
+
+        float delay = Mathf.Max(guardDialogueDelay, 0f);
+        if (delay > 0f)
+            yield return new WaitForSeconds(delay);
+
+        if (guardDialogueBackground != null)
+            guardDialogueBackground.SetActive(false);
+
         if (dialogueUI != null && guardDialogue != null)
         {
             suppressNextStartCheck = true;
+            guardDialogueActive = true;
             dialogueUI.StartDialogue(guardDialogue);
         }
+
+        guardDialogueRoutine = null;
     }
 }

--- a/Assets/Scripts/StartSequence.cs
+++ b/Assets/Scripts/StartSequence.cs
@@ -27,6 +27,7 @@ public class StartSequence : MonoBehaviour
 
     [Header("UI")]
     [SerializeField] private GameObject backgroundPanel;
+    [SerializeField] private int backgroundSortingOrder = -100;
     [SerializeField] private PlayerInteractScript playerInteract;
     [SerializeField] private TMP_Text interactionBlockedLabel;
     [SerializeField] private CanvasGroup interactionBlockedCanvasGroup;
@@ -57,7 +58,10 @@ public class StartSequence : MonoBehaviour
         hasLastTrackedPosition = false;
 
         if (backgroundPanel != null)
+        {
+            ApplyBackgroundLayout();
             backgroundPanel.SetActive(false);
+        }
 
         if (interactionBlockedCanvasGroup != null)
             interactionBlockedCanvasGroup.alpha = 0f;
@@ -134,7 +138,7 @@ public class StartSequence : MonoBehaviour
             return;
 
         if (backgroundPanel != null)
-            backgroundPanel.SetActive(true);
+            ShowBackground();
 
         BlockInteractions();
 
@@ -167,6 +171,7 @@ public class StartSequence : MonoBehaviour
                 StartSkillSelection();
                 break;
             case SequenceStep.DialogueB:
+                HideBackground();
                 StartWaitingForMovement();
                 break;
             case SequenceStep.DialogueC:
@@ -216,6 +221,38 @@ public class StartSequence : MonoBehaviour
         }
 
         dialogueUI.StartDialogue(dialogueStartB);
+    }
+
+    private void ShowBackground()
+    {
+        if (backgroundPanel == null)
+            return;
+
+        ApplyBackgroundLayout();
+        backgroundPanel.SetActive(true);
+    }
+
+    private void HideBackground()
+    {
+        if (backgroundPanel == null)
+            return;
+
+        backgroundPanel.SetActive(false);
+    }
+
+    private void ApplyBackgroundLayout()
+    {
+        if (backgroundPanel == null)
+            return;
+
+        var canvas = backgroundPanel.GetComponent<Canvas>();
+        if (canvas != null)
+        {
+            canvas.overrideSorting = true;
+            canvas.sortingOrder = backgroundSortingOrder;
+        }
+
+        backgroundPanel.transform.SetAsFirstSibling();
     }
 
     private void StartWaitingForMovement()
@@ -313,8 +350,7 @@ public class StartSequence : MonoBehaviour
 
         currentStep = SequenceStep.Completed;
 
-        if (backgroundPanel != null)
-            backgroundPanel.SetActive(false);
+        HideBackground();
 
         if (dialogueUI != null)
             dialogueUI.DialogueClosed -= HandleDialogueClosed;


### PR DESCRIPTION
## Summary
- ensure the start sequence background sits behind dialogue and selection UI and hides after dialogue B
- add guard dialogue background delay and restore moved character after guard dialogue closes

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68da3331b3848330aea4ae9a1dad8aa7