### PR TITLE
Add repeatable toggle to DialogueInteractable

### DIFF
--- a/Assets/Scripts/Interactions/DialogueInteractable.cs
+++ b/Assets/Scripts/Interactions/DialogueInteractable.cs
@@ -1,5 +1,7 @@
-using UnityEngine;
+using System.Collections;
 using Articy.Unity;
+using TMPro;
+using UnityEngine;
 
 /// <summary>
 /// Universal interactable that starts a dialogue when interacted with.
@@ -13,11 +15,20 @@ public class DialogueInteractable : MonoBehaviour, IInteractable
     [Tooltip("Articy start node for the dialogue")]
     public ArticyRef dialogueStart;
 
+    [Header("Repeat")]
+    [SerializeField] private bool repeatable = true;
+    [SerializeField] private TMP_Text repeatBlockedLabel;
+    [SerializeField] private CanvasGroup repeatBlockedCanvasGroup;
+    [SerializeField] private float repeatBlockedFadeDuration = 1f;
+
     private DialogueUI cachedDialogueUI;
+    private Coroutine repeatBlockedRoutine;
+    private bool hasInteracted;
 
     protected virtual void Awake()
     {
         CacheDialogueUI();
+        InitializeRepeatBlockedMessage();
     }
 
     /// <summary>
@@ -25,6 +36,12 @@ public class DialogueInteractable : MonoBehaviour, IInteractable
     /// </summary>
     public void Interact()
     {
+        if (!repeatable && hasInteracted)
+        {
+            ShowRepeatBlockedMessage();
+            return;
+        }
+
         CacheDialogueUI();
 
         if (cachedDialogueUI == null)
@@ -40,11 +57,76 @@ public class DialogueInteractable : MonoBehaviour, IInteractable
         }
 
         cachedDialogueUI.StartDialogue(dialogueStart);
+
+        if (!repeatable)
+            hasInteracted = true;
+    }
+
+    protected virtual void OnDisable()
+    {
+        if (repeatBlockedRoutine != null)
+        {
+            StopCoroutine(repeatBlockedRoutine);
+            repeatBlockedRoutine = null;
+        }
+
+        if (repeatBlockedCanvasGroup != null)
+            repeatBlockedCanvasGroup.alpha = 0f;
+
+        if (repeatBlockedLabel != null)
+            repeatBlockedLabel.text = string.Empty;
     }
 
     private void CacheDialogueUI()
     {
         if (cachedDialogueUI == null)
             cachedDialogueUI = FindObjectOfType<DialogueUI>();
+    }
+
+    private void InitializeRepeatBlockedMessage()
+    {
+        if (repeatBlockedCanvasGroup != null)
+            repeatBlockedCanvasGroup.alpha = 0f;
+
+        if (repeatBlockedLabel != null)
+        {
+            repeatBlockedLabel.text = string.Empty;
+            repeatBlockedLabel.color = Color.white;
+        }
+    }
+
+    private void ShowRepeatBlockedMessage()
+    {
+        if (repeatBlockedLabel == null || repeatBlockedCanvasGroup == null)
+            return;
+
+        repeatBlockedLabel.text = "Nothing interesting here";
+        repeatBlockedLabel.color = Color.white;
+
+        if (repeatBlockedRoutine != null)
+            StopCoroutine(repeatBlockedRoutine);
+
+        repeatBlockedRoutine = StartCoroutine(FadeRepeatBlockedMessage());
+    }
+
+    private IEnumerator FadeRepeatBlockedMessage()
+    {
+        if (repeatBlockedCanvasGroup == null)
+            yield break;
+
+        float duration = Mathf.Max(repeatBlockedFadeDuration, Mathf.Epsilon);
+        repeatBlockedCanvasGroup.alpha = 1f;
+
+        float elapsed = 0f;
+        while (elapsed < duration)
+        {
+            elapsed += Time.deltaTime;
+            float t = Mathf.Clamp01(elapsed / duration);
+            repeatBlockedCanvasGroup.alpha = Mathf.Lerp(1f, 0f, t);
+            yield return null;
+        }
+
+        repeatBlockedCanvasGroup.alpha = 0f;
+        repeatBlockedRoutine = null;
     }
 }


### PR DESCRIPTION
## Summary
- add a repeatable toggle to DialogueInteractable with a default value of true
- block repeated interactions when disabled and surface a "Nothing interesting here" message using the same fade logic as StartSequence

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68da3b9eb92c83309450356e4d9ab4fa