### PR TITLE
Fix hints panel layering and repeat block visibility

### DIFF
--- a/Assets/Scripts/Interactions/DialogueInteractable.cs
+++ b/Assets/Scripts/Interactions/DialogueInteractable.cs
@@ -71,7 +71,10 @@ public class DialogueInteractable : MonoBehaviour, IInteractable
         }
 
         if (repeatBlockedCanvasGroup != null)
+        {
             repeatBlockedCanvasGroup.alpha = 0f;
+            repeatBlockedCanvasGroup.gameObject.SetActive(false);
+        }
 
         if (repeatBlockedLabel != null)
             repeatBlockedLabel.text = string.Empty;
@@ -86,7 +89,10 @@ public class DialogueInteractable : MonoBehaviour, IInteractable
     private void InitializeRepeatBlockedMessage()
     {
         if (repeatBlockedCanvasGroup != null)
+        {
             repeatBlockedCanvasGroup.alpha = 0f;
+            repeatBlockedCanvasGroup.gameObject.SetActive(false);
+        }
 
         if (repeatBlockedLabel != null)
         {
@@ -102,6 +108,7 @@ public class DialogueInteractable : MonoBehaviour, IInteractable
 
         repeatBlockedLabel.text = "Nothing interesting here";
         repeatBlockedLabel.color = Color.white;
+        repeatBlockedCanvasGroup.gameObject.SetActive(true);
 
         if (repeatBlockedRoutine != null)
             StopCoroutine(repeatBlockedRoutine);
@@ -127,6 +134,7 @@ public class DialogueInteractable : MonoBehaviour, IInteractable
         }
 
         repeatBlockedCanvasGroup.alpha = 0f;
+        repeatBlockedCanvasGroup.gameObject.SetActive(false);
         repeatBlockedRoutine = null;
     }
 }

--- a/Assets/Scripts/UI/HintsPanelController.cs
+++ b/Assets/Scripts/UI/HintsPanelController.cs
@@ -16,7 +16,7 @@ public class HintsPanelController : MonoBehaviour
         if (panelRoot == null)
             panelRoot = gameObject;
 
-        EnsurePanelIsLowestLayer();
+        EnsurePanelIsTopLayer();
 
         if (closeButton != null)
             closeButton.onClick.AddListener(HidePanel);
@@ -33,7 +33,7 @@ public class HintsPanelController : MonoBehaviour
     /// </summary>
     public void ShowPanel()
     {
-        EnsurePanelIsLowestLayer();
+        EnsurePanelIsTopLayer();
 
         if (panelRoot != null && !panelRoot.activeSelf)
             panelRoot.SetActive(true);
@@ -65,7 +65,7 @@ public class HintsPanelController : MonoBehaviour
         return panelRoot != null && panelRoot.activeSelf;
     }
 
-    private void EnsurePanelIsLowestLayer()
+    private void EnsurePanelIsTopLayer()
     {
         if (panelRoot == null)
             return;
@@ -73,6 +73,6 @@ public class HintsPanelController : MonoBehaviour
         Transform panelTransform = panelRoot.transform;
 
         if (panelTransform.parent != null)
-            panelTransform.SetAsFirstSibling();
+            panelTransform.SetAsLastSibling();
     }
 }


### PR DESCRIPTION
## Summary
- ensure the hints panel canvas is moved to the top of its hierarchy when shown
- hide the repeat blocked label until a second interaction attempt and disable its canvas group after fading

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68da4def80c083308e43e3dc7ed5fef6