### PR TITLE
Conditionally show loop count in player stats display

### DIFF
--- a/Assets/Scripts/PlayerStatsDisplay.cs
+++ b/Assets/Scripts/PlayerStatsDisplay.cs
@@ -41,10 +41,15 @@ public class PlayerStatsDisplay : MonoBehaviour {
             ? "Skills:\n" + BuildSkillsBlock()
             : "Skills: ";
 
-        targetText.text =
-            $"Moral: {player.moralVal}/{player.moralCap}\n" +
-            $"Loop: {loopState}\n" +
-            skillsSection;
+        var displayBuilder = new StringBuilder();
+        displayBuilder.AppendFormat("Moral: {0}/{1}\n", player.moralVal, player.moralCap);
+
+        if (loopState >= 2)
+            displayBuilder.AppendFormat("Loop: {0}\n", loopState);
+
+        displayBuilder.Append(skillsSection);
+
+        targetText.text = displayBuilder.ToString();
     }
 
     private void CacheShowSkillsButton() {


### PR DESCRIPTION
## Summary
- only render the loop count line in the player stats display once the loop counter reaches two
- refactor the display composition to use a StringBuilder for conditional loop content

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68dd30d2813083309954833ea76b6a18