### PR TITLE
Refactor quest system to rely on QUEST global variables

### DIFF
--- a/Assets/Scripts/LoopResetInputScript.cs
+++ b/Assets/Scripts/LoopResetInputScript.cs
@@ -62,8 +62,6 @@ public class LoopResetInputScript : MonoBehaviour {
     private static void DoLoopReset() {
         Debug.Log("[LoopReset] start");
 
-        QuestManager.ResetTemporary();
-
         GameTime.Instance.Hours = 12;
         GameTime.Instance.Minutes = 12;
 

--- a/Assets/Scripts/QuestManager.cs
+++ b/Assets/Scripts/QuestManager.cs
@@ -13,6 +13,12 @@ public static class QuestManager {
     static QuestManager()
     {
         RegisterWrapper(new StealFromRuQuestWrapper());
+        RegisterWrapper(new BackgroundCheckQuestWrapper());
+        RegisterWrapper(new FindMemoriesQuestWrapper());
+        RegisterWrapper(new AdvertiseQuestWrapper());
+        RegisterWrapper(new GetArtefactQuestWrapper());
+        RegisterWrapper(new PreventMurderAttemptQuestWrapper());
+        RegisterWrapper(new GetGunQuestWrapper());
     }
 
     public static IEnumerable<Quest> GetAllQuests() => quests.Values;
@@ -27,23 +33,13 @@ public static class QuestManager {
         sb.AppendLine($"State: {quest.State}");
         sb.AppendLine($"Stage: {quest.Stage}");
         sb.AppendLine($"Result: {quest.Result}");
-        sb.AppendLine($"Temporary: {quest.IsTemporary}");
-        sb.AppendLine($"Description: {quest.Description}");
         sb.AppendLine($"Current Description: {quest.CurrentDescription}");
-        sb.AppendLine($"Failed Description: {quest.FailedDescription}");
         sb.AppendLine($"Stage Count: {quest.StageCount}");
         if (quest.StageDescriptions.Count > 0)
         {
             sb.AppendLine("Stage Descriptions:");
             for (int i = 0; i < quest.StageDescriptions.Count; i++)
                 sb.AppendLine($"  Stage {i + 1}: {quest.StageDescriptions[i]}");
-        }
-        sb.AppendLine($"Result Count: {quest.ResultCount}");
-        if (quest.ResultDescriptions.Count > 0)
-        {
-            sb.AppendLine("Result Descriptions:");
-            for (int i = 0; i < quest.ResultDescriptions.Count; i++)
-                sb.AppendLine($"  Result {i + 1}: {quest.ResultDescriptions[i]}");
         }
 
         if (quest.Objectives.Count > 0)
@@ -77,35 +73,24 @@ public static class QuestManager {
         public QuestState State;
         public int Stage;                 // ëèíåéíûé ïðîãðåññ/÷åêïîèíò
         public int Result;                // òåêóùèé èòîã êâåñòà
-        public bool IsTemporary;          // RQUE = true, NQUE = false
-        public string Description;
-        public string FailedDescription;
         public readonly List<string> StageDescriptions = new();
-        public readonly List<string> ResultDescriptions = new();
         public readonly Dictionary<string, Objective> Objectives = new();
         public bool LoopChanged;
 
         public int StageCount => StageDescriptions.Count;
-        public int ResultCount => ResultDescriptions.Count;
 
         public string CurrentDescription
         {
             get
             {
-                return State switch
-                {
-                    QuestState.Active => GetStageDescription(Stage),
-                    QuestState.Completed => GetResultDescription(Result),
-                    QuestState.Failed => FailedDescription ?? string.Empty,
-                    _ => Description ?? string.Empty,
-                };
+                return GetStageDescription(Stage);
             }
         }
 
         public string GetStageDescription(int stageIndex)
         {
             if (StageDescriptions.Count == 0)
-                return Description ?? string.Empty;
+                return string.Empty;
 
             if (stageIndex <= 0)
                 stageIndex = 1;
@@ -113,21 +98,7 @@ public static class QuestManager {
             if (stageIndex > StageDescriptions.Count)
                 stageIndex = StageDescriptions.Count;
 
-            return StageDescriptions[stageIndex - 1];
-        }
-
-        public string GetResultDescription(int resultIndex)
-        {
-            if (ResultDescriptions.Count == 0)
-                return Description ?? string.Empty;
-
-            if (resultIndex <= 0)
-                resultIndex = 1;
-
-            if (resultIndex > ResultDescriptions.Count)
-                resultIndex = ResultDescriptions.Count;
-
-            return ResultDescriptions[resultIndex - 1];
+            return StageDescriptions[stageIndex - 1] ?? string.Empty;
         }
     }
 
@@ -161,41 +132,12 @@ public static class QuestManager {
     private static bool _mutePush;
 
     // Áûñòðûå ññûëêè íà íàáîðû ãëîáàëîê Articy
-    private static object RQUE => ArticyGlobalVariables.Default.RQUE;
-    private static object NQUE => ArticyGlobalVariables.Default.NQUE;
-
-    private static string GenerateQuestDescription(string questName) => $"Quest {questName} overview {Guid.NewGuid():N}";
-    private static string GenerateFailedDescription(string questName) => $"Quest {questName} failure {Guid.NewGuid():N}";
-    private static string GenerateStageDescription(string questName, int index) => $"Quest {questName} stage {index} description {Guid.NewGuid():N}";
-    private static string GenerateResultDescription(string questName, int index) => $"Quest {questName} result {index} description {Guid.NewGuid():N}";
-
-    private static void EnsureQuestMetadata(Quest q)
-    {
-        if (q == null)
-            return;
-
-        if (string.IsNullOrEmpty(q.Description))
-            q.Description = GenerateQuestDescription(q.Name);
-
-        if (string.IsNullOrEmpty(q.FailedDescription))
-            q.FailedDescription = GenerateFailedDescription(q.Name);
-
-        if (!TryGetWrapper(q.Name, out _))
-        {
-            if (q.StageDescriptions.Count == 0)
-                q.StageDescriptions.Add(GenerateStageDescription(q.Name, 1));
-        }
-
-        if (q.ResultDescriptions.Count == 0)
-            q.ResultDescriptions.Add(GenerateResultDescription(q.Name, 1));
-    }
+    private static Articy.World_Of_Red_Moon.GlobalVariables.QUEST QuestVariables => ArticyGlobalVariables.Default.QUEST;
 
     private static void EnsureStageCapacity(Quest q, int requiredStageCount)
     {
         if (q == null)
             return;
-
-        EnsureQuestMetadata(q);
 
         if (requiredStageCount <= 0)
             requiredStageCount = 1;
@@ -208,49 +150,23 @@ public static class QuestManager {
 
         while (q.StageDescriptions.Count < requiredStageCount)
         {
-            int nextIndex = q.StageDescriptions.Count + 1;
-            q.StageDescriptions.Add(GenerateStageDescription(q.Name, nextIndex));
-        }
-    }
-
-    private static void EnsureResultCapacity(Quest q, int requiredResultCount)
-    {
-        if (q == null)
-            return;
-
-        EnsureQuestMetadata(q);
-
-        if (requiredResultCount <= 0)
-            requiredResultCount = 1;
-
-        while (q.ResultDescriptions.Count < requiredResultCount)
-        {
-            int nextIndex = q.ResultDescriptions.Count + 1;
-            q.ResultDescriptions.Add(GenerateResultDescription(q.Name, nextIndex));
+            q.StageDescriptions.Add(string.Empty);
         }
     }
 
     // ======== Õåëïåðû ========
     // isTemp: null — íå òðîãàåì; true — âðåìåííûé (RQUE); false — ïîñòîÿííûé (NQUE).
-    private static Quest Ensure(string name, bool? isTemp = null) {
+    private static Quest Ensure(string name) {
         if (!quests.TryGetValue(name, out var q)) {
             q = new Quest {
                 Name = name,
-                IsTemporary = isTemp ?? false, // ïî óìîë÷àíèþ ñ÷èòàåì ïåðñèñòåíòíûì
                 State = QuestState.NotStarted,
                 Stage = 0,
                 Result = 0,
                 LoopChanged = false
             };
             quests[name] = q;
-        } else if (isTemp.HasValue) {
-            // Åñëè ñâåäåíèÿ ïðèøëè èç NQUE — äà¸ì ïðèîðèòåò "íå âðåìåííûì".
-            if (isTemp.Value == false && q.IsTemporary)
-                q.IsTemporary = false;
-            // Åñëè óæå non-temp, íå ïåðåâîäèì îáðàòíî â temp.
-            // Åñëè áûë temp è ïðèøëî temp — îñòàâëÿåì temp.
         }
-        EnsureQuestMetadata(q);
         if (TryGetWrapper(name, out var wrapper))
             wrapper.EnsureStageCapacity(q, Math.Max(q.Stage, 1));
         return q;
@@ -271,12 +187,11 @@ public static class QuestManager {
     public static bool IsCompleted(string name) => quests.TryGetValue(name, out var q) && q.State == QuestState.Completed;
 
     /// <summary>Çàïóñòè ïîñòîÿííûé êâåñò: Start(name, isTemp:false) èëè âðåìåííûé: Start(name, isTemp:true)</summary>
-    public static Quest Start(string name, bool isTemp = false) {
-        var q = Ensure(name, isTemp);
+    public static Quest Start(string name) {
+        var q = Ensure(name);
         q.State = QuestState.Active;
         if (q.Stage == 0) q.Stage = 1;
         EnsureStageCapacity(q, q.Stage);
-        EnsureResultCapacity(q, q.Result);
         PushToArticy(q);
         RaiseQuestChanged(q);
         return q;
@@ -286,7 +201,6 @@ public static class QuestManager {
         if (!quests.TryGetValue(name, out var q)) return;
         q.State = QuestState.Failed;
         EnsureStageCapacity(q, q.Stage);
-        EnsureResultCapacity(q, q.Result);
         PushToArticy(q);
         RaiseQuestChanged(q);
     }
@@ -295,17 +209,15 @@ public static class QuestManager {
         if (!quests.TryGetValue(name, out var q)) return;
         q.State = QuestState.Completed;
         EnsureStageCapacity(q, q.Stage);
-        EnsureResultCapacity(q, q.Result);
         PushToArticy(q);
         RaiseQuestChanged(q);
     }
 
     public static void SetStage(string name, int stage) {
-        var q = Start(name); // òèï (temp/non-temp) óæå äîëæåí áûòü îïðåäåë¸í ðàíåå èëè ïî óìîë÷àíèþ non-temp
+        var q = Start(name);
         q.Stage = stage;
         if (q.State == QuestState.NotStarted) q.State = QuestState.Active;
         EnsureStageCapacity(q, stage);
-        EnsureResultCapacity(q, q.Result);
         PushToArticy(q);
         RaiseQuestChanged(q);
     }
@@ -323,38 +235,28 @@ public static class QuestManager {
             : QuestState.NotStarted;
     }
 
-    public static void ResetTemporary() {
-        var toRemove = new List<string>();
-        foreach (var kv in quests)
-            if (kv.Value.IsTemporary) toRemove.Add(kv.Key);
-
-        foreach (var name in toRemove) {
-            // 1) îáíóëÿåì çåðêàëüíûå ïåðåìåííûå èìåííî â RQUE (òîëüêî ïî ïðåôèêñó êâåñòà)
-            ClearQuestInArticy(name, RQUE);
-
-            // 2) óáèðàåì èç ëîêàëüíîãî ðååñòðà
-            quests.Remove(name);
-        }
-    }
-
     public static void OnLoopReset()
     {
         foreach (var quest in quests.Values)
         {
             quest.LoopChanged = false;
 
-            if (!TryGetWrapper(quest.Name, out var wrapper))
-                continue;
-
             int previousStage = quest.Stage;
 
-            wrapper.OnLoopReset(quest);
-            wrapper.EnsureStageCapacity(quest, Math.Max(quest.Stage, 1));
+            if (TryGetWrapper(quest.Name, out var wrapper))
+            {
+                wrapper.OnLoopReset(quest);
+                wrapper.EnsureStageCapacity(quest, Math.Max(quest.Stage, 1));
+            }
+            else if ((quest.Stage & 1) == 1)
+            {
+                quest.Stage += 1;
+                EnsureStageCapacity(quest, Math.Max(quest.Stage, 1));
+            }
 
             if (quest.Stage != previousStage)
             {
                 quest.LoopChanged = true;
-                EnsureResultCapacity(quest, quest.Result);
                 PushToArticy(quest);
                 RaiseQuestChanged(quest);
             }
@@ -366,7 +268,7 @@ public static class QuestManager {
     public static string DisplayQuests() {
         var sb = new StringBuilder();
         foreach (var q in quests.Values) {
-            sb.Append($"{q.Name} [State:{q.State}, Stage:{q.Stage}, Result:{q.Result}, Temp:{q.IsTemporary}]");
+            sb.Append($"{q.Name} [State:{q.State}, Stage:{q.Stage}, Result:{q.Result}]");
             if (q.Objectives.Count > 0) {
                 sb.Append(" {");
                 bool first = true;
@@ -390,7 +292,7 @@ public static class QuestManager {
         if (_mutePush) return; // íå óñòðàèâàåì ïèíã-ïîíã âî âðåìÿ Sync
 
         try {
-            var gv = q.IsTemporary ? RQUE : NQUE;
+            var gv = QuestVariables;
 
             SetInt(gv, $"{q.Name}_State", (int)q.State);
             SetInt(gv, $"{q.Name}_Result", q.Result);
@@ -412,36 +314,18 @@ public static class QuestManager {
     }
 
     // Îáíóëèòü âñå int/bool ïåðåìåííûå êâåñòà ïî ïðåôèêñó "<questName>_" âíóòðè óêàçàííîãî íàáîðà (RQUE èëè NQUE).
-    private static void ClearQuestInArticy(string questName, object gvset) {
-        try {
-            var type = gvset.GetType();
-            foreach (var p in type.GetProperties()) {
-                if (!p.Name.StartsWith(questName + "_")) continue;
-
-                if (p.PropertyType == typeof(int))
-                    p.SetValue(gvset, 0);
-                else if (p.PropertyType == typeof(bool))
-                    p.SetValue(gvset, false);
-            }
-        } catch (System.Exception e) {
-            UnityEngine.Debug.LogWarning($"ClearQuestInArticy({questName}): {e.Message}");
-        }
-    }
-
     // Ïîäòÿæêà ñîñòîÿíèÿ èç Articy â ëîêàëüíîå õðàíèëèùå.
-    // Òåïåðü ÷èòàåì è RQUE (isTemp=true), è NQUE (isTemp=false).
-    // Ñòàðûå bool (íàïðèìåð *_Started) êîíâåðòèðóåì â Active îäèí ðàç.
+    // ÷èòàåì íàáîð QUEST è îáíîâëÿåì ëîêàëüíûå äàííûå êâåñòîâ.
     public static void SyncFromArticy() {
         _mutePush = true;
         try {
-            ProcessGVSet(RQUE, isTemp: true);
-            ProcessGVSet(NQUE, isTemp: false);
+            ProcessQuestVariables(QuestVariables);
         } finally {
             _mutePush = false;
         }
     }
 
-    private static void ProcessGVSet(object gv, bool isTemp) {
+    private static void ProcessQuestVariables(object gv) {
         try {
             var props = gv.GetType().GetProperties();
 
@@ -452,33 +336,30 @@ public static class QuestManager {
 
                     if (key.EndsWith("_State")) {
                         var questName = key.Substring(0, key.Length - "_State".Length);
-                        var q = Ensure(questName, isTemp);
+                        var q = Ensure(questName);
                         var newState = (QuestState)val;
                         if (TryGetWrapper(questName, out var stateWrapper))
                             newState = stateWrapper.ProcessStateFromArticy(q, newState);
                         q.State = newState;
                         EnsureStageCapacity(q, q.Stage);
-                        EnsureResultCapacity(q, q.Result);
                         RaiseQuestChanged(q);
                     } else if (key.EndsWith("_Stage")) {
                         var questName = key.Substring(0, key.Length - "_Stage".Length);
-                        var q = Ensure(questName, isTemp);
+                        var q = Ensure(questName);
                         int newStage = val;
                         if (TryGetWrapper(questName, out var stageWrapper))
                             newStage = stageWrapper.ProcessStageFromArticy(q, newStage);
                         q.Stage = newStage;
                         if (q.State == QuestState.NotStarted && newStage > 0) q.State = QuestState.Active;
                         EnsureStageCapacity(q, newStage);
-                        EnsureResultCapacity(q, q.Result);
                         RaiseQuestChanged(q);
                     } else if (key.EndsWith("_Result")) {
                         var questName = key.Substring(0, key.Length - "_Result".Length);
-                        var q = Ensure(questName, isTemp);
+                        var q = Ensure(questName);
                         int newResult = val;
                         if (TryGetWrapper(questName, out var resultWrapper))
                             newResult = resultWrapper.ProcessResultFromArticy(q, newResult);
                         q.Result = newResult;
-                        EnsureResultCapacity(q, newResult);
                         EnsureStageCapacity(q, q.Stage);
                         RaiseQuestChanged(q);
                     } else if (key.Contains("_Obj_")) {
@@ -486,7 +367,7 @@ public static class QuestManager {
                         if (parts.Length == 2) {
                             var questName = parts[0];
                             var objId = parts[1];
-                            var q = Ensure(questName, isTemp);
+                            var q = Ensure(questName);
                             EnsureObjective(q, objId, (QuestState)val);
                             RaiseQuestChanged(q);
                         }
@@ -496,7 +377,7 @@ public static class QuestManager {
                     bool started = (bool)p.GetValue(gv);
                     if (started && p.Name.EndsWith("_Started")) {
                         string questName = p.Name.Substring(0, p.Name.Length - "_Started".Length);
-                        var q = Ensure(questName, isTemp);
+                        var q = Ensure(questName);
                         if (q.State == QuestState.NotStarted) {
                             q.State = QuestState.Active;
                             if (q.Stage == 0) q.Stage = 1;
@@ -506,7 +387,7 @@ public static class QuestManager {
                 }
             }
         } catch (Exception e) {
-            Debug.LogWarning($"QuestManager.ProcessGVSet({(isTemp ? "RQUE" : "NQUE")}): {e.Message}");
+            Debug.LogWarning($"QuestManager.ProcessQuestVariables: {e.Message}");
         }
     }
 

--- a/Assets/Scripts/QuestWrappers/AdditionalQuestWrappers.cs
+++ b/Assets/Scripts/QuestWrappers/AdditionalQuestWrappers.cs
@@ -1,0 +1,41 @@
+public sealed class BackgroundCheckQuestWrapper : QuestWrapper
+{
+    public BackgroundCheckQuestWrapper() : base("BackgroundCheck")
+    {
+    }
+}
+
+public sealed class FindMemoriesQuestWrapper : QuestWrapper
+{
+    public FindMemoriesQuestWrapper() : base("FindMemories")
+    {
+    }
+}
+
+public sealed class AdvertiseQuestWrapper : QuestWrapper
+{
+    public AdvertiseQuestWrapper() : base("advertise")
+    {
+    }
+}
+
+public sealed class GetArtefactQuestWrapper : QuestWrapper
+{
+    public GetArtefactQuestWrapper() : base("getArtefact")
+    {
+    }
+}
+
+public sealed class PreventMurderAttemptQuestWrapper : QuestWrapper
+{
+    public PreventMurderAttemptQuestWrapper() : base("preventMurderAttempt")
+    {
+    }
+}
+
+public sealed class GetGunQuestWrapper : QuestWrapper
+{
+    public GetGunQuestWrapper() : base("getGun")
+    {
+    }
+}

--- a/Assets/Scripts/QuestWrappers/AdditionalQuestWrappers.cs.meta
+++ b/Assets/Scripts/QuestWrappers/AdditionalQuestWrappers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d6b2d80c7b74f249a9f5a2c4125d1b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/QuestWrappers/QuestWrapper.cs
+++ b/Assets/Scripts/QuestWrappers/QuestWrapper.cs
@@ -38,13 +38,12 @@ public abstract class QuestWrapper
 
         quest.StageDescriptions.Clear();
 
-        string lastDescription = quest.Description ?? string.Empty;
         for (int stage = 1; stage <= maxStage; stage++)
         {
-            if (stageDescriptions.TryGetValue(stage, out var desc) && !string.IsNullOrEmpty(desc))
-                lastDescription = desc;
-
-            quest.StageDescriptions.Add(lastDescription);
+            if (stageDescriptions.TryGetValue(stage, out var desc))
+                quest.StageDescriptions.Add(desc ?? string.Empty);
+            else
+                quest.StageDescriptions.Add(string.Empty);
         }
     }
 


### PR DESCRIPTION
## Summary
- pull quest data exclusively from the QUEST Articy set and drop resettable/permanent branching
- simplify quest descriptions to stage-based output and register wrappers for every QUEST quest
- remove temporary quest reset handling during loop reset while keeping stage progression updates consistent

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68dd592dcb3083309040e7fd89d35721