### PR TITLE
feat: allow configuring quest loop reset increments

### DIFF
--- a/Assets/Scripts/QuestWrappers/QuestWrapper.cs
+++ b/Assets/Scripts/QuestWrappers/QuestWrapper.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 public abstract class QuestWrapper
 {
     private readonly Dictionary<int, string> stageDescriptions = new();
+    private readonly HashSet<int> stagesToAdvanceOnLoopReset = new();
 
     protected QuestWrapper(string questName)
     {
@@ -53,6 +54,18 @@ public abstract class QuestWrapper
 
     public virtual int ProcessResultFromArticy(QuestManager.Quest quest, int result) => result;
 
+    protected void AddStagesToAdvanceOnLoopReset(params int[] stages)
+    {
+        if (stages == null)
+            return;
+
+        foreach (var stage in stages)
+        {
+            if (stage > 0)
+                stagesToAdvanceOnLoopReset.Add(stage);
+        }
+    }
+
     public virtual void OnLoopReset(QuestManager.Quest quest)
     {
         if (quest == null)
@@ -61,7 +74,7 @@ public abstract class QuestWrapper
         if (quest.State == QuestState.NotStarted)
             return;
 
-        if ((quest.Stage & 1) == 1)
+        if (stagesToAdvanceOnLoopReset.Contains(quest.Stage))
             quest.Stage += 1;
     }
 }


### PR DESCRIPTION
## Summary
- add support for quest wrappers to register specific stages that should advance during a loop reset

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68de228db68c8330af9ae285bc25943b