### PR TITLE
fix: adjust steal from ru stage transition logic

### DIFF
--- a/Assets/Scripts/QuestWrappers/StealFromRuQuestWrapper.cs
+++ b/Assets/Scripts/QuestWrappers/StealFromRuQuestWrapper.cs
@@ -24,6 +24,14 @@ public sealed class StealFromRuQuestWrapper : QuestWrapper
                 return 4;
         }
 
+        if (stage == 5)
+        {
+            if (quest?.Stage == 1)
+                return 5;
+
+            return 6;
+        }
+
         return base.ProcessStageFromArticy(quest, stage);
     }
 }


### PR DESCRIPTION
## Summary
- ensure the stealFromRu quest only advances to stage 5 from stage 1 and otherwise goes to stage 6

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68de36d3621483308936b6c6346fb258