### PR TITLE
feat: update quest state handling based on stages

### DIFF
--- a/Assets/Scripts/QuestManager.cs
+++ b/Assets/Scripts/QuestManager.cs
@@ -154,6 +154,15 @@ public static class QuestManager {
         }
     }
 
+    private static void ApplyWrapperStageState(Quest quest)
+    {
+        if (quest == null)
+            return;
+
+        if (TryGetWrapper(quest.Name, out var wrapper))
+            wrapper.ApplyStageStateForCurrentStage(quest);
+    }
+
     // ======== Õåëïåðû ========
     // isTemp: null — íå òðîãàåì; true — âðåìåííûé (RQUE); false — ïîñòîÿííûé (NQUE).
     private static Quest Ensure(string name) {
@@ -217,6 +226,7 @@ public static class QuestManager {
         var q = Start(name);
         q.Stage = stage;
         if (q.State == QuestState.NotStarted) q.State = QuestState.Active;
+        ApplyWrapperStageState(q);
         EnsureStageCapacity(q, stage);
         PushToArticy(q);
         RaiseQuestChanged(q);
@@ -247,6 +257,7 @@ public static class QuestManager {
             {
                 wrapper.OnLoopReset(quest);
                 wrapper.EnsureStageCapacity(quest, Math.Max(quest.Stage, 1));
+                wrapper.ApplyStageStateForCurrentStage(quest);
             }
             else if ((quest.Stage & 1) == 1)
             {
@@ -341,6 +352,7 @@ public static class QuestManager {
                         if (TryGetWrapper(questName, out var stateWrapper))
                             newState = stateWrapper.ProcessStateFromArticy(q, newState);
                         q.State = newState;
+                        ApplyWrapperStageState(q);
                         EnsureStageCapacity(q, q.Stage);
                         RaiseQuestChanged(q);
                     } else if (key.EndsWith("_Stage")) {
@@ -351,6 +363,7 @@ public static class QuestManager {
                             newStage = stageWrapper.ProcessStageFromArticy(q, newStage);
                         q.Stage = newStage;
                         if (q.State == QuestState.NotStarted && newStage > 0) q.State = QuestState.Active;
+                        ApplyWrapperStageState(q);
                         EnsureStageCapacity(q, newStage);
                         RaiseQuestChanged(q);
                     } else if (key.EndsWith("_Result")) {

--- a/Assets/Scripts/QuestWrappers/StealFromRuQuestWrapper.cs
+++ b/Assets/Scripts/QuestWrappers/StealFromRuQuestWrapper.cs
@@ -13,6 +13,8 @@ public sealed class StealFromRuQuestWrapper : QuestWrapper
         SetStageDescription(7, "Теперь Ратко отвечает на мои вопросы. Точнее, отвечает на те вопросы, на которые хочет отвечать. Это лучше, чем ничего.");
         SetStageDescription(8, "Если я хочу, чтобы Ратко снова мне помогал, я должна снова принести ему эти кубы. Что ж, я уже знаю, как их получить.");
         AddStagesToAdvanceOnLoopReset(1, 5, 7);
+        MarkStageAsFailed(3, 4);
+        MarkStageAsCompleted(7);
     }
 
     public override int ProcessStageFromArticy(QuestManager.Quest quest, int stage)
@@ -33,5 +35,21 @@ public sealed class StealFromRuQuestWrapper : QuestWrapper
         }
 
         return base.ProcessStageFromArticy(quest, stage);
+    }
+
+    public override void OnLoopReset(QuestManager.Quest quest)
+    {
+        if (quest == null)
+            return;
+
+        bool wasFailed = quest.State == QuestState.Failed;
+
+        base.OnLoopReset(quest);
+
+        if (wasFailed)
+        {
+            quest.Stage = 2;
+            quest.State = QuestState.Active;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow quest wrappers to tag stages that should force Failed or Completed quest states
- apply the stage-to-state rules whenever quests change stage or sync from Articy
- ensure stealFromRu resets to stage 2 on loop reset after a failure

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68de4062fdac8330a67387a4d953611d