### PR TITLE
feat: add trigger-controlled music toggle

### DIFF
--- a/Assets/Scripts/MusicManager.cs
+++ b/Assets/Scripts/MusicManager.cs
@@ -1,8 +1,23 @@
+using System.Collections;
 using UnityEngine;
 
 public class MusicManager : MonoBehaviour
 {
     [SerializeField] private AudioSource audioSource;
+
+    private AudioClip defaultClip;
+    private float defaultVolume = 1f;
+    private Coroutine transitionRoutine;
+    private bool isAlternateActive;
+
+    private void Awake()
+    {
+        if (audioSource != null)
+        {
+            defaultClip = audioSource.clip;
+            defaultVolume = audioSource.volume;
+        }
+    }
 
     private void Start()
     {
@@ -12,7 +27,73 @@ public class MusicManager : MonoBehaviour
             return;
         }
 
+        if (audioSource.clip == null && defaultClip != null)
+        {
+            audioSource.clip = defaultClip;
+        }
+
+        audioSource.volume = defaultVolume;
         audioSource.loop = true;
         audioSource.Play();
+    }
+
+    public void ToggleAlternateTrack(AudioClip alternateClip, float fadeDuration)
+    {
+        if (audioSource == null)
+        {
+            Debug.LogWarning("MusicManager: No AudioSource assigned for toggling");
+            return;
+        }
+
+        if (alternateClip == null && !isAlternateActive)
+        {
+            Debug.LogWarning("MusicManager: Alternate clip not provided for toggle");
+            return;
+        }
+
+        AudioClip targetClip = isAlternateActive ? defaultClip : alternateClip;
+
+        if (targetClip == null)
+        {
+            Debug.LogWarning("MusicManager: Target clip missing during toggle");
+            return;
+        }
+
+        if (transitionRoutine != null)
+        {
+            StopCoroutine(transitionRoutine);
+        }
+
+        transitionRoutine = StartCoroutine(SwapMusicRoutine(targetClip, fadeDuration));
+        isAlternateActive = !isAlternateActive;
+    }
+
+    private IEnumerator SwapMusicRoutine(AudioClip nextClip, float fadeDuration)
+    {
+        float initialVolume = audioSource.volume;
+        float duration = Mathf.Max(0.01f, fadeDuration);
+
+        for (float elapsed = 0f; elapsed < duration; elapsed += Time.deltaTime)
+        {
+            float t = elapsed / duration;
+            audioSource.volume = Mathf.Lerp(initialVolume, 0f, t);
+            yield return null;
+        }
+
+        audioSource.volume = 0f;
+        audioSource.Stop();
+
+        audioSource.clip = nextClip;
+        audioSource.Play();
+
+        for (float elapsed = 0f; elapsed < duration; elapsed += Time.deltaTime)
+        {
+            float t = elapsed / duration;
+            audioSource.volume = Mathf.Lerp(0f, defaultVolume, t);
+            yield return null;
+        }
+
+        audioSource.volume = defaultVolume;
+        transitionRoutine = null;
     }
 }

--- a/Assets/Scripts/MusicToggleTrigger.cs
+++ b/Assets/Scripts/MusicToggleTrigger.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+public class MusicToggleTrigger : MonoBehaviour
+{
+    [SerializeField] private Collider triggerCollider;
+    [SerializeField] private MusicManager musicManager;
+    [SerializeField] private AudioClip alternateClip;
+    [SerializeField] private float fadeDuration = 1f;
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (triggerCollider == null)
+        {
+            Debug.LogWarning("MusicToggleTrigger: Trigger collider reference missing", this);
+            return;
+        }
+
+        if (other != triggerCollider)
+        {
+            return;
+        }
+
+        if (musicManager == null)
+        {
+            Debug.LogWarning("MusicToggleTrigger: MusicManager reference missing", this);
+            return;
+        }
+
+        musicManager.ToggleAlternateTrack(alternateClip, fadeDuration);
+    }
+}

--- a/Assets/Scripts/MusicToggleTrigger.cs.meta
+++ b/Assets/Scripts/MusicToggleTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a64ebfe4d341405e86f403937192b7b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add trigger-driven behaviour to switch between the default and alternate background music
- fade music in and out over a configurable duration when toggling tracks
- provide a trigger helper component to hook up the alternate clip and toggle collider in the editor

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e0fac89b58833089034ab873ff14ab